### PR TITLE
Add array metrics, Documentation, and Examples corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The exporter uses a RESTful API schema to provide Prometheus scraping endpoints.
 
 
 URL | GET parameters | Description
----|---
+---|---|---
 http://\<exporter-host\>:\<port\>/metrics | endpoint | Full array metrics
 http://\<exporter-host\>:\<port\>/metrics/array | endpoint | Array only metrics
 http://\<exporter-host\>:\<port\>/metrics/volumes | endpoint | Volumes only metrics

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -9,6 +9,6 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -v -o /usr/local/bin/pure-fa-om-exporter cmd/fa-om-exporter/main.go
 
-EXPOSE 9491
+EXPOSE 9490
 ENTRYPOINT ["/usr/local/bin/pure-fa-om-exporter"]
 CMD ["--host", "0.0.0.0", "--port", "9490"]

--- a/cmd/fa-om-exporter/main.go
+++ b/cmd/fa-om-exporter/main.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"strings"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
-	"purestorage/fa-openmetrics-exporter/internal/openmetrics-exporter"
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	collectors "purestorage/fa-openmetrics-exporter/internal/openmetrics-exporter"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var version string = "0.2.0"
+var version string = "0.2.1"
 var debug bool = false
 
 func main() {
@@ -57,6 +58,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		metrics = path[2]
 		switch metrics {
+		case "array":
 		case "volumes":
 		case "hosts":
 		case "pods":
@@ -94,7 +96,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 func index(w http.ResponseWriter, r *http.Request) {
 	msg := `<html>
 <body>
-<h1>Pure Storage Flashblade OpenMetrics Exporter</h1>
+<h1>Pure Storage FlashArray OpenMetrics Exporter</h1>
 <table>
     <thead>
         <tr>
@@ -110,6 +112,12 @@ func index(w http.ResponseWriter, r *http.Request) {
             <td><a href="/metrics?endpoint=host">/metrics</a></td>
             <td>endpoint</td>
             <td>All array metrics. Expect slow response time.</td>
+        </tr>
+        <tr>
+            <td>Array metrics</td>
+            <td><a href="/metrics/array?endpoint=host">/metrics/array</a></td>
+            <td>endpoint</td>
+            <td>Provides only array related metrics.</td>
         </tr>
         <tr>
             <td>Volumes metrics</td>

--- a/examples/config/docker/README.md
+++ b/examples/config/docker/README.md
@@ -4,5 +4,5 @@ Launch the exporter using the docker command according to the following:
 
 ```shell
 
-docker run -d -p 9491:9491  --rm --name pure-fa-om-exporter quai.io/purestorage/pure-fa-om-exporter:<version>
+docker run -d -p 9490:9490  --rm --name pure-fa-om-exporter quay.io/purestorage/pure-fa-om-exporter:<version>
 ```

--- a/examples/config/k8s/prometheus-configmap.yaml
+++ b/examples/config/k8s/prometheus-configmap.yaml
@@ -25,7 +25,7 @@ data:
 
     # A scrape configuration containing exactly one endpoint to scrape:
     scrape_configs:
-      - job_name: 'purestorage-fb'
+      - job_name: 'purestorage-fa'
         metrics_path: /metrics/array
         authorization:
           credentials: T-2b74f9eb-a35f-40d9-a6a6-33c13775a53c
@@ -33,7 +33,7 @@ data:
           endpoint: ['10.11.112.6']
         static_configs:
         - targets:
-          - pure-fb-exporter.monitoring.svc:9491
+          - pure-fa-exporter.monitoring.svc:9490
           labels:
             location: uk
             site: London


### PR DESCRIPTION
When reviewing this, I found that /metrics/array was listed in the README.md, but it was missing in `metricsHandler` function. I have added it, I have also added its link to the landing page. 

I also found a few port numbers referring the old port of 9491, instead of the new default port of 9490.

Please reach out if you have any questions.