### PR TITLE
Adding capacity dimension to purefa_array_space_bytes

### DIFF
--- a/cmd/fa-om-exporter/main.go
+++ b/cmd/fa-om-exporter/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var version string = "1.0.0"
+var version string = "1.0.1"
 var debug bool = false
 
 func main() {

--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -102,6 +102,11 @@ func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue,
 		a.Space.TotalEffective, "total_effective",
 	)
+	ch <- prometheus.MustNewConstMetric(
+		c.SpaceDesc,
+		prometheus.GaugeValue,
+		a.Capacity-a.Space.System-a.Space.Replication-a.Space.Shared-a.Space.Snapshots-a.Space.Unique, "empty",
+	)
 }
 
 func NewArraySpaceCollector(fa *client.FAClient) *ArraySpaceCollector {

--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -7,9 +7,10 @@ import (
 )
 
 type ArraySpaceCollector struct {
-	ReductionDesc *prometheus.Desc
-	SpaceDesc     *prometheus.Desc
-	Client        *client.FAClient
+	ReductionDesc   *prometheus.Desc
+	SpaceDesc       *prometheus.Desc
+	UtilizationDesc *prometheus.Desc
+	Client          *client.FAClient
 }
 
 func (c *ArraySpaceCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -108,9 +109,9 @@ func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		a.Capacity-a.Space.System-a.Space.Replication-a.Space.Shared-a.Space.Snapshots-a.Space.Unique, "empty",
 	)
 	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
+		c.UtilizationDesc,
 		prometheus.GaugeValue,
-		(a.Space.System+a.Space.Replication+a.Space.Shared+a.Space.Snapshots+a.Space.Unique)/a.Capacity*100, "utilization",
+		(a.Space.System+a.Space.Replication+a.Space.Shared+a.Space.Snapshots+a.Space.Unique)/a.Capacity*100,
 	)
 }
 
@@ -126,6 +127,12 @@ func NewArraySpaceCollector(fa *client.FAClient) *ArraySpaceCollector {
 			"purefa_array_space_bytes",
 			"FlashArray array space in bytes",
 			[]string{"space"},
+			prometheus.Labels{},
+		),
+		UtilizationDesc: prometheus.NewDesc(
+			"purefa_array_space_utilization",
+			"FlashArray array space utilization in percent",
+			[]string{},
 			prometheus.Labels{},
 		),
 		Client: fa,

--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -1,9 +1,9 @@
 package collectors
 
-
 import (
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 type ArraySpaceCollector struct {
@@ -26,6 +26,11 @@ func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		c.ReductionDesc,
 		prometheus.GaugeValue,
 		a.Space.DataReduction,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.SpaceDesc,
+		prometheus.GaugeValue,
+		a.Capacity, "capacity",
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.SpaceDesc,

--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -107,6 +107,11 @@ func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue,
 		a.Capacity-a.Space.System-a.Space.Replication-a.Space.Shared-a.Space.Snapshots-a.Space.Unique, "empty",
 	)
+	ch <- prometheus.MustNewConstMetric(
+		c.SpaceDesc,
+		prometheus.GaugeValue,
+		(a.Space.System+a.Space.Replication+a.Space.Shared+a.Space.Snapshots+a.Space.Unique)/a.Capacity*100, "utilization",
+	)
 }
 
 func NewArraySpaceCollector(fa *client.FAClient) *ArraySpaceCollector {

--- a/internal/rest-client/arrays.go
+++ b/internal/rest-client/arrays.go
@@ -1,44 +1,42 @@
 package client
 
-
 type Array struct {
-	Id              string             `json:"id"`
-	Name            string             `json:"name"`
-	Banner          string             `json:"banner"`
-        Capacity        int                `json:"capacity"`
-        ConsoleLock     bool               `json:"console_lock_enabled"`
-        Encryption      Encryption         `json:"encryption"`
-        EradicationConfig  EradicationConfig     `json:"eradication_config"`
-	IdleTimeout     int                `json:"idle_timeout"`
-	NtpServers      []string           `json:"ntp_servers"`
-	Os              string             `json:"os"`
-        Parity          float64            `json:"parity"`
-        SCSITimeo       int                `json:"scsi_timeout"`
-        Space           Space              `json:"space"`
-	Version         string             `json:"version"`
+	Id                string            `json:"id"`
+	Name              string            `json:"name"`
+	Banner            string            `json:"banner"`
+	Capacity          float64           `json:"capacity"`
+	ConsoleLock       bool              `json:"console_lock_enabled"`
+	Encryption        Encryption        `json:"encryption"`
+	EradicationConfig EradicationConfig `json:"eradication_config"`
+	IdleTimeout       int               `json:"idle_timeout"`
+	NtpServers        []string          `json:"ntp_servers"`
+	Os                string            `json:"os"`
+	Parity            float64           `json:"parity"`
+	SCSITimeo         int               `json:"scsi_timeout"`
+	Space             Space             `json:"space"`
+	Version           string            `json:"version"`
 }
 
 type Encryption struct {
-	DataAtRest      DataAtRest    `json:"data_at_rest"`
-        ModuleVersion   string        `json:"module_version"`
-        
+	DataAtRest    DataAtRest `json:"data_at_rest"`
+	ModuleVersion string     `json:"module_version"`
 }
 
 type DataAtRest struct {
-	Algorithm    string     `json:"algorithm"`
-	Enabled      bool       `json:"enabled"`
+	Algorithm string `json:"algorithm"`
+	Enabled   bool   `json:"enabled"`
 }
 
 type EradicationConfig struct {
-	EradicationDelay     int      `json:"eradication_delay"`
-	ManualEradication    string   `json:"manual_eradication"`
+	EradicationDelay  int    `json:"eradication_delay"`
+	ManualEradication string `json:"manual_eradication"`
 }
 
 type ArraysList struct {
-	ContinuationToken    string  `json:"continuation_token"`
-	TotalItemCount       int     `json:"total_item_count"`
-        MoreItemsRemaining   bool    `json:"more_items_remaining"`
-	Items                []Array `json:"items"`
+	ContinuationToken  string  `json:"continuation_token"`
+	TotalItemCount     int     `json:"total_item_count"`
+	MoreItemsRemaining bool    `json:"more_items_remaining"`
+	Items              []Array `json:"items"`
 }
 
 func (fa *FAClient) GetArrays() *ArraysList {
@@ -49,15 +47,15 @@ func (fa *FAClient) GetArrays() *ArraysList {
 	if err != nil {
 		fa.Error = err
 	}
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+	}
 	res, err = fa.RestClient.R().
 		SetResult(&result).
 		Get("/arrays")
-        if err != nil {
-                fa.Error = err
-        }
+	if err != nil {
+		fa.Error = err
+	}
 
 	return result
 }


### PR DESCRIPTION
There was no total capacity metric coming out of the exporter. I have added it to the `purefa_array_space_bytes` metrics. 

VS Code also picked up some syntax too. Happy to remove those if you'd like.