### PR TITLE
added option to set api key as get parameter

### DIFF
--- a/internal/rest-client/flasharray_client.go
+++ b/internal/rest-client/flasharray_client.go
@@ -114,6 +114,6 @@ func (fa *FAClient) RefreshSession() *FAClient {
 		return fa
 	}
 	fa.XAuthToken = res.Header().Get("x-auth-token")
-	fa.RestClient.SetHeader("x-auth-token", fa.XAuthToken)
+	fa.RestClient.R().SetHeader("x-auth-token", fa.XAuthToken)
 	return fa
 }


### PR DESCRIPTION
This PR reintroduces behavior from an older exporter where API keys can be supplied as GET parameter. Doing so allows using a single scrape config for multiple arrays that all use different API keys which in turn simplifies alerting rules (because job_name is identical). It removes the requirement to have one scrape config per target configured as is the case today.

**WARNING** using this feature will result in API keys being visible in the target list in Prometheus. Use with read-only keys only and be be aware of the security implications. This function only works when the exporter is started using a new flag `-secret_parameter` to enable this functionality only on purpose. 

Example Prometheus config
```
  - job_name: pure_fa                                                                                                                                                                                                                                                             
    honor_labels: true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
    metrics_path: /metrics                                                                                                                                                                                                                                                        
    scrape_interval: 10s                                                                                                                                                                                                                                                          
    relabel_configs:                                                                                                                                                                                                                                                              
      - source_labels: [__address__]                                                                                                                                                                                                                                              
        target_label: __param_endpoint                                                                                                                                                                                                                                            
      - source_labels: [__pure_api_token]                                                                                                                                                                                                                                         
        target_label: __param_api_token
      - target_label: __address__
        replacement: localhost:9490
    file_sd_configs:
      - files:
        - /etc/prometheus/targets/pure.yml
```

Example file_sd contents:
```
- targets: [ pure01.foo.com ]
  labels:
    __pure_api_token: 1234
- targets: [ pure02.foo.com ]
  labels:
    __pure_api_token: 5678
```