### PR TITLE
Remove apk cache at build time.

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=1 go build -a -tags 'netgo osusergo static_build' -ldflags="-X m
 # alpine is used here as it seems to be the minimal image that passes quay.io vulnerability scan
 FROM alpine
 # update ssl packages for CVEs
-RUN apk update && apk add --upgrade libcrypto3 libssl3
+RUN apk update && apk add --upgrade libcrypto3 libssl3 && rm -rf /var/cache/apk/*
 COPY --from=build  /usr/local/bin/pure-fa-om-exporter /pure-fa-om-exporter
 
 # create an empty tokens file for use with volumes if required. You can use a mounted volume to /etc/pure-fa-om-exporter/ to pass the `tokens.yaml` file. File must be named `tokens.yaml`.


### PR DESCRIPTION
To save ~2MB to the build size, we can remove the APK cache at build time. 