### PR TITLE
[bug] allow for , in alert description strings that are collected

### DIFF
--- a/internal/openmetrics-exporter/alerts_collector.go
+++ b/internal/openmetrics-exporter/alerts_collector.go
@@ -24,7 +24,7 @@ func (c *AlertsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	al := make(map[string]float64)
 	for _, alert := range alerts.Items {
-		al[fmt.Sprintf("%s,%d,%s,%d,%s,%s,%s,%s",
+		al[fmt.Sprintf("%s\n%d\n%s\n%d\n%s\n%s\n%s\n%s",
 			alert.Category,
 			alert.Code,
 			alert.ComponentType,
@@ -36,7 +36,7 @@ func (c *AlertsCollector) Collect(ch chan<- prometheus.Metric) {
 		)] += 1
 	}
 	for a, n := range al {
-		alert := strings.Split(a, ",")
+		alert := strings.Split(a, "\n")
 		ch <- prometheus.MustNewConstMetric(
 			c.AlertsDesc,
 			prometheus.GaugeValue,

--- a/internal/rest-client/flasharray_client.go
+++ b/internal/rest-client/flasharray_client.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-//	"log"
+	//	"log"
 	"crypto/tls"
 	"errors"
+
 	"github.com/go-resty/resty/v2"
 )
 
@@ -44,7 +45,7 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, debug bo
 		EndPoint:   endpoint,
 		ApiToken:   apitoken,
 		RestClient: resty.New(),
-	        XAuthToken: "",
+		XAuthToken: "",
 	}
 	fa.RestClient.SetBaseURL("https://" + endpoint + "/api")
 	fa.RestClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
@@ -55,10 +56,10 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, debug bo
 	if debug {
 		fa.RestClient.SetDebug(true)
 	}
-//	fa.RestClient.OnRequestLog(func(rl *resty.RequestLog) error {
-//		fmt.Fprintln(os.Stderr, rl)
-//		return nil
-//	})
+	//	fa.RestClient.OnRequestLog(func(rl *resty.RequestLog) error {
+	//		fmt.Fprintln(os.Stderr, rl)
+	//		return nil
+	//	})
 
 	result := new(ApiVersions)
 	res, err := fa.RestClient.R().
@@ -69,11 +70,11 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, debug bo
 		return fa
 	}
 	if res.StatusCode() != 200 {
-		fa.Error = errors.New("Not a valid FlashArray REST API server")
+		fa.Error = errors.New("not a valid FlashArray REST API server")
 		return fa
 	}
 	if len(result.Versions) == 0 {
-		fa.Error = errors.New("Not a valid FlashArray REST API version")
+		fa.Error = errors.New("not a valid FlashArray REST API version")
 		return fa
 	}
 	if apiversion == "latest" {


### PR DESCRIPTION
closes #108

Currently in alerts_collector.go we use the `,` breaker. There are some alerts in purity that in the description include the `,` character, causing the map that is used to become malformed. 

This change is to change the delimiter from `,` to /n to correct this issue.