### PR TITLE
Correct Dockerfile to use mod=readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Binary downloads of the exporter can be found on the [Releases](https://github.c
 
 The following commands describe how to run a typical build :
 ```shell
-
 # clone the repository
 git clone git@github.com:PureStorage-OpenConnect/pure-fa-openmetrics-exporter.git
 
@@ -54,7 +53,13 @@ cd pure-fa-openmetrics-exporter
 make build .
 ```
 
-The newly built exporter executable can be found in the <kbd>./out/bin</kbd> directory.
+The newly built exporter binary can be found in the <kbd>./out/bin</kbd> directory.
+
+Optionally, to build the binary with the vendor cache, you may use
+
+````
+make build-with-vendor
+````
 
 ### Docker Image
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN CGO_ENABLED=1 go build -a -tags 'netgo osusergo static_build' -ldflags="-X main.version=v$VERSION" -v -o /usr/local/bin/pure-fa-om-exporter cmd/fa-om-exporter/main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -a -tags 'netgo osusergo static_build' -ldflags="-X main.version=v$VERSION" -v -o /usr/local/bin/pure-fa-om-exporter cmd/fa-om-exporter/main.go
 
 
 # alpine is used here as it seems to be the minimal image that passes quay.io vulnerability scan


### PR DESCRIPTION
Please include in 1.0.15

due to #121 , it is best to build dockerfile with mod=readonly to not use the vendor dir, unless directed. 