### PR TITLE
[bug] Fix if statements on error handling when encountering 401 on scrape.

### DIFF
--- a/internal/rest-client/alerts.go
+++ b/internal/rest-client/alerts.go
@@ -40,12 +40,13 @@ func (fa *FAClient) GetAlerts(filter string) *AlertsList {
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = req.Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = req.Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/arrays.go
+++ b/internal/rest-client/arrays.go
@@ -18,20 +18,19 @@ type Array struct {
 }
 
 type ArrayShort struct {
-        Id                string     `json:"id"`
-        Name              string     `json:"name"`
-        FrozenAt          int        `json:"frozen_at"`
-        MediatorStatus    string     `json:"mediator_status"`
-        PreElected        bool       `json:"pre_elected"`
-        Progress          float64    `json:"progress"`
-        Status            string     `json:"status"`
+	Id             string  `json:"id"`
+	Name           string  `json:"name"`
+	FrozenAt       int     `json:"frozen_at"`
+	MediatorStatus string  `json:"mediator_status"`
+	PreElected     bool    `json:"pre_elected"`
+	Progress       float64 `json:"progress"`
+	Status         string  `json:"status"`
 }
 
 type ArrayTiny struct {
-        Id      string     `json:"id"`
-        Name    string     `json:"name"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
-
 
 type Encryption struct {
 	DataAtRest    DataAtRest `json:"data_at_rest"`
@@ -64,14 +63,15 @@ func (fa *FAClient) GetArrays() *ArraysList {
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/arrays_performance.go
+++ b/internal/rest-client/arrays_performance.go
@@ -1,47 +1,46 @@
 package client
 
-
 type ArrayPerformance struct {
-	Name      string  `json:"name"`
-	Id      string  `json:"id"`
-	BytesPerMirroredWrite      float64  `json:"bytes_per_mirrored_write"`
-	BytesPerOp      float64  `json:"bytes_per_op"`
-	BytesPerRead      float64  `json:"bytes_per_read"`
-	BytesPerWrite      float64  `json:"bytes_per_write"`
-	MirroredWriteBytesPerSec      float64  `json:"mirrored_write_bytes_per_sec"`
-	MirroredWritesPerSec      float64  `json:"mirrored_writes_per_sec"`
-	QosRateLimitUsecPerMirroredWriteOp      float64  `json:"qos_rate_limit_usec_per_mirrored_write_op"`
-	QosRateLimitUsecPerReadOp      float64  `json:"qos_rate_limit_usec_per_read_op"`
-	QosRateLimitUsecPerWriteOp      float64  `json:"qos_rate_limit_usec_per_write_op"`
-	QueueUsecPerMirroredWriteOp      float64  `json:"queue_usec_per_mirrored_write_op"`
-	QueueUsecPerReadOp      float64  `json:"queue_usec_per_read_op"`
-	QueueUsecPerWriteOp      float64  `json:"queue_usec_per_write_op"`
-	ReadBytesPerSec      float64  `json:"read_bytes_per_sec"`
-	ReadsPerSec      float64  `json:"reads_per_sec"`
-	SanUsecPerMirroredWriteOp      float64  `json:"san_usec_per_mirrored_write_op"`
-	SanUsecPerReadOp      float64  `json:"san_usec_per_read_op"`
-	SanUsecPerWriteOp      float64  `json:"san_usec_per_write_op"`
-	ServiceUsecPerMirroredWriteOp      float64  `json:"service_usec_per_mirrored_write_op"`
-	ServiceUsecPerReadOp      float64  `json:"service_usec_per_read_op"`
-	ServiceUsecPerWriteOp      float64  `json:"service_usec_per_write_op"`
-	Time      int  `json:"time"`
-	UsecPerMirroredWriteOp      float64  `json:"usec_per_mirrored_write_op"`
-	UsecPerReadOp      float64  `json:"usec_per_read_op"`
-	UsecPerWriteOp      float64  `json:"usec_per_write_op"`
-	WriteBytesPerSec      float64  `json:"write_bytes_per_sec"`
-	WritesPerSec      float64  `json:"writes_per_sec"`
-	ServiceUsecPerReadOpCacheReduction      float64  `json:"service_usec_per_read_op_cache_reduction"`
-	QueueDepth      float64  `json:"queue_depth"`
-	LocalQueueUsecPerOp      float64  `json:"local_queue_usec_per_op"`
-	UsecPerOtherOp      float64  `json:"usec_per_other_op"`
-	OthersPerSec      float64  `json:"others_per_sec"`
+	Name                               string  `json:"name"`
+	Id                                 string  `json:"id"`
+	BytesPerMirroredWrite              float64 `json:"bytes_per_mirrored_write"`
+	BytesPerOp                         float64 `json:"bytes_per_op"`
+	BytesPerRead                       float64 `json:"bytes_per_read"`
+	BytesPerWrite                      float64 `json:"bytes_per_write"`
+	MirroredWriteBytesPerSec           float64 `json:"mirrored_write_bytes_per_sec"`
+	MirroredWritesPerSec               float64 `json:"mirrored_writes_per_sec"`
+	QosRateLimitUsecPerMirroredWriteOp float64 `json:"qos_rate_limit_usec_per_mirrored_write_op"`
+	QosRateLimitUsecPerReadOp          float64 `json:"qos_rate_limit_usec_per_read_op"`
+	QosRateLimitUsecPerWriteOp         float64 `json:"qos_rate_limit_usec_per_write_op"`
+	QueueUsecPerMirroredWriteOp        float64 `json:"queue_usec_per_mirrored_write_op"`
+	QueueUsecPerReadOp                 float64 `json:"queue_usec_per_read_op"`
+	QueueUsecPerWriteOp                float64 `json:"queue_usec_per_write_op"`
+	ReadBytesPerSec                    float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec                        float64 `json:"reads_per_sec"`
+	SanUsecPerMirroredWriteOp          float64 `json:"san_usec_per_mirrored_write_op"`
+	SanUsecPerReadOp                   float64 `json:"san_usec_per_read_op"`
+	SanUsecPerWriteOp                  float64 `json:"san_usec_per_write_op"`
+	ServiceUsecPerMirroredWriteOp      float64 `json:"service_usec_per_mirrored_write_op"`
+	ServiceUsecPerReadOp               float64 `json:"service_usec_per_read_op"`
+	ServiceUsecPerWriteOp              float64 `json:"service_usec_per_write_op"`
+	Time                               int     `json:"time"`
+	UsecPerMirroredWriteOp             float64 `json:"usec_per_mirrored_write_op"`
+	UsecPerReadOp                      float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp                     float64 `json:"usec_per_write_op"`
+	WriteBytesPerSec                   float64 `json:"write_bytes_per_sec"`
+	WritesPerSec                       float64 `json:"writes_per_sec"`
+	ServiceUsecPerReadOpCacheReduction float64 `json:"service_usec_per_read_op_cache_reduction"`
+	QueueDepth                         float64 `json:"queue_depth"`
+	LocalQueueUsecPerOp                float64 `json:"local_queue_usec_per_op"`
+	UsecPerOtherOp                     float64 `json:"usec_per_other_op"`
+	OthersPerSec                       float64 `json:"others_per_sec"`
 }
 
 type ArraysPerformanceList struct {
-	ContinuationToken    string  `json:"continuation_token"`
-	TotalItemCount       int     `json:"total_item_count"`
-        MoreItemsRemaining   bool    `json:"more_items_remaining"`
-	Items                []ArrayPerformance `json:"items"`
+	ContinuationToken  string             `json:"continuation_token"`
+	TotalItemCount     int                `json:"total_item_count"`
+	MoreItemsRemaining bool               `json:"more_items_remaining"`
+	Items              []ArrayPerformance `json:"items"`
 }
 
 func (fa *FAClient) GetArraysPerformance() *ArraysPerformanceList {
@@ -50,19 +49,19 @@ func (fa *FAClient) GetArraysPerformance() *ArraysPerformanceList {
 	res, err := fa.RestClient.R().
 		SetResult(&result).
 		Get(uri)
-
 	if err != nil {
 		fa.Error = err
 	}
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
 	return result
 }

--- a/internal/rest-client/connections.go
+++ b/internal/rest-client/connections.go
@@ -39,18 +39,18 @@ func (fa *FAClient) GetConnections() *ConnectionsList {
 	res, err := fa.RestClient.R().
 		SetResult(&result).
 		Get(uri)
-
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/directories.go
+++ b/internal/rest-client/directories.go
@@ -1,68 +1,67 @@
 package client
 
-
 type FileSystem struct {
-	Id      string     `json:"id"`
-	Name    string     `json:"name"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type Member struct {
-	Id              string     `json:"id"`
-	Name            string     `json:"name"`
-	ResourceType    string     `json:"resource_type"`
+	Id           string `json:"id"`
+	Name         string `json:"name"`
+	ResourceType string `json:"resource_type"`
 }
 
 type Policy struct {
-	Id              string     `json:"id"`
-	Name            string     `json:"name"`
-	ResourceType    string     `json:"resource_type"`
+	Id           string `json:"id"`
+	Name         string `json:"name"`
+	ResourceType string `json:"resource_type"`
 }
 
 type LimitedBy struct {
-	Member          Member     `json:"member"`
-	Policy          Policy     `json:"policy"`
+	Member Member `json:"member"`
+	Policy Policy `json:"policy"`
 }
 
 type Directory struct {
-	Id               string              `json:"id"`
-	Name             string              `json:"name"`
-	Created          int                 `json:"created"`
-	Destroyed        bool                `json:"destroyed"`
-	DirectoryName    string              `json:"directory_name"`
-	FileSystem       FileSystem          `json:"file_system"`
-	Path             string              `json:"path"`
-	Space            Space               `json:"space"`
-	TimeRemaining    int                 `json:"time_remaining"`
-	LimitedBy        LimitedBy           `json:"limited_by"`
+	Id            string     `json:"id"`
+	Name          string     `json:"name"`
+	Created       int        `json:"created"`
+	Destroyed     bool       `json:"destroyed"`
+	DirectoryName string     `json:"directory_name"`
+	FileSystem    FileSystem `json:"file_system"`
+	Path          string     `json:"path"`
+	Space         Space      `json:"space"`
+	TimeRemaining int        `json:"time_remaining"`
+	LimitedBy     LimitedBy  `json:"limited_by"`
 }
 
 type DirectoriesList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []Directory `json:"items"`
-        Total                []Directory `json:"total"`
+	ContinuationToken  string      `json:"continuation_token"`
+	TotalItemCount     int         `json:"total_item_count"`
+	MoreItemsRemaining bool        `json:"more_items_remaining"`
+	Items              []Directory `json:"items"`
+	Total              []Directory `json:"total"`
 }
 
 func (fa *FAClient) GetDirectories() *DirectoriesList {
 	uri := "/directories"
-        result := new(DirectoriesList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(DirectoriesList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/directories_performance.go
+++ b/internal/rest-client/directories_performance.go
@@ -1,50 +1,49 @@
 package client
 
-
 type DirectoryPerformance struct {
-	Id      string  `json:"id"`
-	Name      string  `json:"name"`
-	BytesPerOp      float64  `json:"bytes_per_op"`
-	BytesPerRead      float64  `json:"bytes_per_read"`
-	BytesPerWrite      float64  `json:"bytes_per_write"`
-	OthersPerSec      float64  `json:"others_per_sec"`
-	ReadBytesPerSec      float64  `json:"read_bytes_per_sec"`
-	ReadsPerSec      float64  `json:"reads_per_sec"`
-	Time      int  `json:"time"`
-	UsecPerOtherOp      float64  `json:"usec_per_other_op"`
-	UsecPerReadOp      float64  `json:"usec_per_read_op"`
-	UsecPerWriteOp      float64  `json:"usec_per_write_op"`
-	WriteBytesPerSec      float64  `json:"write_bytes_per_sec"`
-	WritesPerSec      float64  `json:"writes_per_sec"`
+	Id               string  `json:"id"`
+	Name             string  `json:"name"`
+	BytesPerOp       float64 `json:"bytes_per_op"`
+	BytesPerRead     float64 `json:"bytes_per_read"`
+	BytesPerWrite    float64 `json:"bytes_per_write"`
+	OthersPerSec     float64 `json:"others_per_sec"`
+	ReadBytesPerSec  float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec      float64 `json:"reads_per_sec"`
+	Time             int     `json:"time"`
+	UsecPerOtherOp   float64 `json:"usec_per_other_op"`
+	UsecPerReadOp    float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp   float64 `json:"usec_per_write_op"`
+	WriteBytesPerSec float64 `json:"write_bytes_per_sec"`
+	WritesPerSec     float64 `json:"writes_per_sec"`
 }
 
 type DirectoriesPerformanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []DirectoryPerformance `json:"items"`
-        Total                []DirectoryPerformance `json:"total"`
+	ContinuationToken  string                 `json:"continuation_token"`
+	TotalItemCount     int                    `json:"total_item_count"`
+	MoreItemsRemaining bool                   `json:"more_items_remaining"`
+	Items              []DirectoryPerformance `json:"items"`
+	Total              []DirectoryPerformance `json:"total"`
 }
 
 func (fa *FAClient) GetDirectoriesPerformance() *DirectoriesPerformanceList {
 	uri := "/directories/performance"
-        result := new(DirectoriesPerformanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(DirectoriesPerformanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/drives.go
+++ b/internal/rest-client/drives.go
@@ -1,20 +1,19 @@
 package client
 
-
 type Drive struct {
-	Name          string    `json:"name"`
-	Details       string    `json:"details"`
-	Capacity      float64   `json:"capacity"`
-	Protocol      string    `json:"protocol"`
-	Status        string    `json:"status"`
-	Type          string    `json:"type"`
+	Name     string  `json:"name"`
+	Details  string  `json:"details"`
+	Capacity float64 `json:"capacity"`
+	Protocol string  `json:"protocol"`
+	Status   string  `json:"status"`
+	Type     string  `json:"type"`
 }
 
 type DriveList struct {
-        ContinuationToken    string      `json:"continuation_token"`
-        TotalItemCount       int         `json:"total_item_count"`
-        MoreItemsRemaining   bool        `json:"more_items_remaining"`
-	Items                []Drive     `json:"items"`
+	ContinuationToken  string  `json:"continuation_token"`
+	TotalItemCount     int     `json:"total_item_count"`
+	MoreItemsRemaining bool    `json:"more_items_remaining"`
+	Items              []Drive `json:"items"`
 }
 
 func (fa *FAClient) GetDrives() *DriveList {
@@ -26,15 +25,16 @@ func (fa *FAClient) GetDrives() *DriveList {
 	if err != nil {
 		fa.Error = err
 	}
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
 	return result
 }

--- a/internal/rest-client/hardware.go
+++ b/internal/rest-client/hardware.go
@@ -1,26 +1,25 @@
 package client
 
-
 type Hardware struct {
-	Name          string    `json:"name"`
-	Details       string    `json:"details"`
-	IdentityEnabled bool    `json:"identity_enabled"`
-	Index         int       `json:"index"`
-	Model         string    `json:"model"`
-	Serial        string    `json:"serial"`
-	Slot          int       `json:"slot"`
-	Speed         int       `json:"speed"`
-	Status        string    `json:"status"`
-	Temperature   int       `json:"temperature"`
-	Type          string    `json:"type"`
-	Voltage       int       `json:"voltage"`
+	Name            string `json:"name"`
+	Details         string `json:"details"`
+	IdentityEnabled bool   `json:"identity_enabled"`
+	Index           int    `json:"index"`
+	Model           string `json:"model"`
+	Serial          string `json:"serial"`
+	Slot            int    `json:"slot"`
+	Speed           int    `json:"speed"`
+	Status          string `json:"status"`
+	Temperature     int    `json:"temperature"`
+	Type            string `json:"type"`
+	Voltage         int    `json:"voltage"`
 }
 
 type HardwareList struct {
-        ContinuationToken    string      `json:"continuation_token"`
-        TotalItemCount       int         `json:"total_item_count"`
-        MoreItemsRemaining   bool        `json:"more_items_remaining"`
-	Items                []Hardware  `json:"items"`
+	ContinuationToken  string     `json:"continuation_token"`
+	TotalItemCount     int        `json:"total_item_count"`
+	MoreItemsRemaining bool       `json:"more_items_remaining"`
+	Items              []Hardware `json:"items"`
 }
 
 func (fa *FAClient) GetHardware() *HardwareList {
@@ -32,15 +31,16 @@ func (fa *FAClient) GetHardware() *HardwareList {
 	if err != nil {
 		fa.Error = err
 	}
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
 	return result
 }

--- a/internal/rest-client/hosts.go
+++ b/internal/rest-client/hosts.go
@@ -1,58 +1,57 @@
 package client
 
-
 type Chap struct {
-	HostPassword      string    `json:"host_password"`
-	HostUser          string    `json:"host_user"`
-	TargetPassword    string    `json:"target_password"`
-	TargetUser        string    `json:"target_user"`
+	HostPassword   string `json:"host_password"`
+	HostUser       string `json:"host_user"`
+	TargetPassword string `json:"target_password"`
+	TargetUser     string `json:"target_user"`
 }
 
 type PortConnectivity struct {
-	Details    string    `json:"details"`
-	Status     string    `json:"status"`
+	Details string `json:"details"`
+	Status  string `json:"status"`
 }
 
 type Host struct {
-	Name                string              `json:"name"`
-	Chap                Chap                `json:"chap"`
-	ConnectionCount     int                 `json:"connection_count"`
-	HostGroup           HostGroupShort      `json:"host_group"`
-	IQNs                []string            `json:"iqns"`
-	NQNs                []string            `json:"nqns"`
-	Personality         string              `json:"personality"`
-	PortConnectivity    PortConnectivity    `json:"port_connectivity"`
-	Space               Space               `json:"space"`
-	PreferredArrays     []ArrayShort        `json:"preferred_arrays"`
-	WWNs                []string            `json:"wwns"`
-	IsLocal             bool                `json:"is_local"`
+	Name             string           `json:"name"`
+	Chap             Chap             `json:"chap"`
+	ConnectionCount  int              `json:"connection_count"`
+	HostGroup        HostGroupShort   `json:"host_group"`
+	IQNs             []string         `json:"iqns"`
+	NQNs             []string         `json:"nqns"`
+	Personality      string           `json:"personality"`
+	PortConnectivity PortConnectivity `json:"port_connectivity"`
+	Space            Space            `json:"space"`
+	PreferredArrays  []ArrayShort     `json:"preferred_arrays"`
+	WWNs             []string         `json:"wwns"`
+	IsLocal          bool             `json:"is_local"`
 }
 
 type HostsList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []Host   `json:"items"`
+	ContinuationToken  string `json:"continuation_token"`
+	TotalItemCount     int    `json:"total_item_count"`
+	MoreItemsRemaining bool   `json:"more_items_remaining"`
+	Items              []Host `json:"items"`
 }
 
 func (fa *FAClient) GetHosts() *HostsList {
 	uri := "/hosts"
-        result := new(HostsList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(HostsList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
-        return result
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
+	return result
 }

--- a/internal/rest-client/hosts_balance.go
+++ b/internal/rest-client/hosts_balance.go
@@ -1,57 +1,56 @@
 package client
 
-
 type Initiator struct {
-	Iqn     string   `json:"iqn"`
-	Nqn     string   `json:"nqn"`
-	Portal  string   `json:"portal"`
-	Wwn     string   `json:"wwn"`
+	Iqn    string `json:"iqn"`
+	Nqn    string `json:"nqn"`
+	Portal string `json:"portal"`
+	Wwn    string `json:"wwn"`
 }
 
 type Target struct {
-	Name    string   `json:"name"`
-	Iqn     string   `json:"iqn"`
-	Nqn     string   `json:"nqn"`
-	Portal  string   `json:"portal"`
-	Wwn     string   `json:"wwn"`
-        Failover string  `json:"failover"`
+	Name     string `json:"name"`
+	Iqn      string `json:"iqn"`
+	Nqn      string `json:"nqn"`
+	Portal   string `json:"portal"`
+	Wwn      string `json:"wwn"`
+	Failover string `json:"failover"`
 }
 
 type HostBalance struct {
-	Name                       string     `json:"name"`
-	Op_count                   int     `json:"op_count"`
-	Fraction_relative_to_max   float64     `json:"fraction_relative_to_max"`
-	Initiator                  Initiator     `json:"initiator"`
-	Target                     Target     `json:"target"`
-	Time                       int     `json:"time"`
+	Name                     string    `json:"name"`
+	Op_count                 int       `json:"op_count"`
+	Fraction_relative_to_max float64   `json:"fraction_relative_to_max"`
+	Initiator                Initiator `json:"initiator"`
+	Target                   Target    `json:"target"`
+	Time                     int       `json:"time"`
 }
 
 type HostsBalanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []HostBalance `json:"items"`
+	ContinuationToken  string        `json:"continuation_token"`
+	TotalItemCount     int           `json:"total_item_count"`
+	MoreItemsRemaining bool          `json:"more_items_remaining"`
+	Items              []HostBalance `json:"items"`
 }
 
 func (fa *FAClient) GetHostsBalance() *HostsBalanceList {
 	uri := "/hosts/performance/balance"
-        result := new(HostsBalanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(HostsBalanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/hosts_performance.go
+++ b/internal/rest-client/hosts_performance.go
@@ -1,64 +1,63 @@
 package client
 
-
 type HostPerformance struct {
-	Name      string  `json:"name"`
-	BytesPerMirroredWrite      float64  `json:"bytes_per_mirrored_write"`
-	BytesPerOp      float64  `json:"bytes_per_op"`
-	BytesPerRead      float64  `json:"bytes_per_read"`
-	BytesPerWrite      float64  `json:"bytes_per_write"`
-	MirroredWriteBytesPerSec      float64  `json:"mirrored_write_bytes_per_sec"`
-	MirroredWritesPerSec      float64  `json:"mirrored_writes_per_sec"`
-	QosRateLimitUsecPerMirroredWriteOp      float64  `json:"qos_rate_limit_usec_per_mirrored_write_op"`
-	QosRateLimitUsecPerReadOp      float64  `json:"qos_rate_limit_usec_per_read_op"`
-	QosRateLimitUsecPerWriteOp      float64  `json:"qos_rate_limit_usec_per_write_op"`
-	QueueUsecPerMirroredWriteOp      float64  `json:"queue_usec_per_mirrored_write_op"`
-	QueueUsecPerReadOp      float64  `json:"queue_usec_per_read_op"`
-	QueueUsecPerWriteOp      float64  `json:"queue_usec_per_write_op"`
-	ReadBytesPerSec      float64  `json:"read_bytes_per_sec"`
-	ReadsPerSec      float64  `json:"reads_per_sec"`
-	SanUsecPerMirroredWriteOp      float64  `json:"san_usec_per_mirrored_write_op"`
-	SanUsecPerReadOp      float64  `json:"san_usec_per_read_op"`
-	SanUsecPerWriteOp      float64  `json:"san_usec_per_write_op"`
-	ServiceUsecPerMirroredWriteOp      float64  `json:"service_usec_per_mirrored_write_op"`
-	ServiceUsecPerReadOp      float64  `json:"service_usec_per_read_op"`
-	ServiceUsecPerWriteOp      float64  `json:"service_usec_per_write_op"`
-	Time      int  `json:"time"`
-	UsecPerMirroredWriteOp      float64  `json:"usec_per_mirrored_write_op"`
-	UsecPerReadOp      float64  `json:"usec_per_read_op"`
-	UsecPerWriteOp      float64  `json:"usec_per_write_op"`
-	WriteBytesPerSec      float64  `json:"write_bytes_per_sec"`
-	WritesPerSec      float64  `json:"writes_per_sec"`
-	ServiceUsecPerReadOpCacheReduction      float64  `json:"service_usec_per_read_op_cache_reduction"`
+	Name                               string  `json:"name"`
+	BytesPerMirroredWrite              float64 `json:"bytes_per_mirrored_write"`
+	BytesPerOp                         float64 `json:"bytes_per_op"`
+	BytesPerRead                       float64 `json:"bytes_per_read"`
+	BytesPerWrite                      float64 `json:"bytes_per_write"`
+	MirroredWriteBytesPerSec           float64 `json:"mirrored_write_bytes_per_sec"`
+	MirroredWritesPerSec               float64 `json:"mirrored_writes_per_sec"`
+	QosRateLimitUsecPerMirroredWriteOp float64 `json:"qos_rate_limit_usec_per_mirrored_write_op"`
+	QosRateLimitUsecPerReadOp          float64 `json:"qos_rate_limit_usec_per_read_op"`
+	QosRateLimitUsecPerWriteOp         float64 `json:"qos_rate_limit_usec_per_write_op"`
+	QueueUsecPerMirroredWriteOp        float64 `json:"queue_usec_per_mirrored_write_op"`
+	QueueUsecPerReadOp                 float64 `json:"queue_usec_per_read_op"`
+	QueueUsecPerWriteOp                float64 `json:"queue_usec_per_write_op"`
+	ReadBytesPerSec                    float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec                        float64 `json:"reads_per_sec"`
+	SanUsecPerMirroredWriteOp          float64 `json:"san_usec_per_mirrored_write_op"`
+	SanUsecPerReadOp                   float64 `json:"san_usec_per_read_op"`
+	SanUsecPerWriteOp                  float64 `json:"san_usec_per_write_op"`
+	ServiceUsecPerMirroredWriteOp      float64 `json:"service_usec_per_mirrored_write_op"`
+	ServiceUsecPerReadOp               float64 `json:"service_usec_per_read_op"`
+	ServiceUsecPerWriteOp              float64 `json:"service_usec_per_write_op"`
+	Time                               int     `json:"time"`
+	UsecPerMirroredWriteOp             float64 `json:"usec_per_mirrored_write_op"`
+	UsecPerReadOp                      float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp                     float64 `json:"usec_per_write_op"`
+	WriteBytesPerSec                   float64 `json:"write_bytes_per_sec"`
+	WritesPerSec                       float64 `json:"writes_per_sec"`
+	ServiceUsecPerReadOpCacheReduction float64 `json:"service_usec_per_read_op_cache_reduction"`
 }
 
 type HostsPerformanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []HostPerformance `json:"items"`
-        Total                []HostPerformance `json:"total"`
+	ContinuationToken  string            `json:"continuation_token"`
+	TotalItemCount     int               `json:"total_item_count"`
+	MoreItemsRemaining bool              `json:"more_items_remaining"`
+	Items              []HostPerformance `json:"items"`
+	Total              []HostPerformance `json:"total"`
 }
 
 func (fa *FAClient) GetHostsPerformance() *HostsPerformanceList {
 	uri := "/hosts/performance"
-        result := new(HostsPerformanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(HostsPerformanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/network_interface.go
+++ b/internal/rest-client/network_interface.go
@@ -50,14 +50,15 @@ func (fa *FAClient) GetNetworkInterfaces() *NetworkInterfacesList {
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/network_performance.go
+++ b/internal/rest-client/network_performance.go
@@ -50,14 +50,15 @@ func (fa *FAClient) GetNetworkInterfacesPerformance() *NetworkInterfacesPerforma
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/pod_replica_links_lag.go
+++ b/internal/rest-client/pod_replica_links_lag.go
@@ -1,49 +1,48 @@
 package client
 
-
 type Lag struct {
-        Avg    float64     `json:"avg"`
-        Max    float64     `json:"max"`
+	Avg float64 `json:"avg"`
+	Max float64 `json:"max"`
 }
 
 type PodReplicaLinksLag struct {
-	Id         string  `json:"id"`
-	Lag        Lag  `json:"lag"`
-	Time       int  `json:"time"`
-	Remotes    []ArrayTiny `json:"remotes"`
-	LocalPod   PodShort    `json:"local_pod"`
-	RemotePod  PodShort    `json:"remote_pod"`
-	Direction  string   `json:"direction"`
-	Status     string   `json:"status"`
-	RecoveryPoint     int   `json:"recovery_point"`
+	Id            string      `json:"id"`
+	Lag           Lag         `json:"lag"`
+	Time          int         `json:"time"`
+	Remotes       []ArrayTiny `json:"remotes"`
+	LocalPod      PodShort    `json:"local_pod"`
+	RemotePod     PodShort    `json:"remote_pod"`
+	Direction     string      `json:"direction"`
+	Status        string      `json:"status"`
+	RecoveryPoint int         `json:"recovery_point"`
 }
 
 type PodReplicaLinksLagList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []PodReplicaLinksLag `json:"items"`
+	ContinuationToken  string               `json:"continuation_token"`
+	TotalItemCount     int                  `json:"total_item_count"`
+	MoreItemsRemaining bool                 `json:"more_items_remaining"`
+	Items              []PodReplicaLinksLag `json:"items"`
 }
 
 func (fa *FAClient) GetPodReplicaLinksLag() *PodReplicaLinksLagList {
 	uri := "/pod-replica-links/lag"
-        result := new(PodReplicaLinksLagList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(PodReplicaLinksLagList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/pod_replica_links_performance.go
+++ b/internal/rest-client/pod_replica_links_performance.go
@@ -1,45 +1,44 @@
 package client
 
-
 type PodReplicaLinksPerformance struct {
-	Id        string  `json:"id"`
-	Time      int  `json:"time"`
-	Remotes   []ArrayTiny `json:"remotes"`
-	BytesPerSecFromRemote float64 `json:"bytes_per_sec_from_remote"`
-	BytesPerSecToRemote  float64 `json:"bytes_per_sec_to_remote"`
-	BytesPerSecTotal    float64 `json:"bytes_per_sec_total"`
-	LocalPod   PodShort    `json:"local_pod"`
-	RemotePod  PodShort    `json:"remote_pod"`
-	Direction  string   `json:"direction"`
+	Id                    string      `json:"id"`
+	Time                  int         `json:"time"`
+	Remotes               []ArrayTiny `json:"remotes"`
+	BytesPerSecFromRemote float64     `json:"bytes_per_sec_from_remote"`
+	BytesPerSecToRemote   float64     `json:"bytes_per_sec_to_remote"`
+	BytesPerSecTotal      float64     `json:"bytes_per_sec_total"`
+	LocalPod              PodShort    `json:"local_pod"`
+	RemotePod             PodShort    `json:"remote_pod"`
+	Direction             string      `json:"direction"`
 }
 
 type PodReplicaLinksPerformanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []PodReplicaLinksPerformance `json:"items"`
-        Total                []PodReplicaLinksPerformance `json:"total"`
+	ContinuationToken  string                       `json:"continuation_token"`
+	TotalItemCount     int                          `json:"total_item_count"`
+	MoreItemsRemaining bool                         `json:"more_items_remaining"`
+	Items              []PodReplicaLinksPerformance `json:"items"`
+	Total              []PodReplicaLinksPerformance `json:"total"`
 }
 
 func (fa *FAClient) GetPodReplicaLinksPerformance() *PodReplicaLinksPerformanceList {
 	uri := "/pod-replica-links/performance/replication"
-        result := new(PodReplicaLinksPerformanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(PodReplicaLinksPerformanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/pods.go
+++ b/internal/rest-client/pods.go
@@ -1,58 +1,57 @@
 package client
 
-
 type Pod struct {
-	Id                       string              `json:"id"`
-	Name                     string              `json:"name"`
-	Arrays                   []ArrayShort        `json:"arrays"`
-	Destroyed                bool                `json:"destroyed"`
-	FailoverPreferences      []Array             `json:"failover_preferences"`
-	Footprint                int                 `json:"footprint"`
-	Mediator                 string              `json:"mediator"`
-	MediatorVersion          string              `json:"mediator_version"`
-	Source                   Source              `json:"source"`
-	Space                    Space               `json:"space"`
-	TimeRemaining            int                 `json:"time_remaining"`
-	RequestedPromotionState  string              `json:"requested_promotion_state"`
-	PromotionStatus          string              `json:"promotion_status"`
-	LinkSourceCount          int                 `json:"link_source_count"`
-	LinkTargetCount          int                 `json:"link_target_count"`
-	ArrayCount               int                 `json:"array_count"`
-	EradicationConfig        EradicationConfig   `json:"eradication_config"`
+	Id                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	Arrays                  []ArrayShort      `json:"arrays"`
+	Destroyed               bool              `json:"destroyed"`
+	FailoverPreferences     []Array           `json:"failover_preferences"`
+	Footprint               int               `json:"footprint"`
+	Mediator                string            `json:"mediator"`
+	MediatorVersion         string            `json:"mediator_version"`
+	Source                  Source            `json:"source"`
+	Space                   Space             `json:"space"`
+	TimeRemaining           int               `json:"time_remaining"`
+	RequestedPromotionState string            `json:"requested_promotion_state"`
+	PromotionStatus         string            `json:"promotion_status"`
+	LinkSourceCount         int               `json:"link_source_count"`
+	LinkTargetCount         int               `json:"link_target_count"`
+	ArrayCount              int               `json:"array_count"`
+	EradicationConfig       EradicationConfig `json:"eradication_config"`
 }
 
 type PodsList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []Pod    `json:"items"`
-        Total                []Pod    `json:"total"`
+	ContinuationToken  string `json:"continuation_token"`
+	TotalItemCount     int    `json:"total_item_count"`
+	MoreItemsRemaining bool   `json:"more_items_remaining"`
+	Items              []Pod  `json:"items"`
+	Total              []Pod  `json:"total"`
 }
 
 type PodShort struct {
-        Id      string     `json:"id"`
-        Name    string     `json:"name"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
 
 func (fa *FAClient) GetPods() *PodsList {
 	uri := "/pods"
-        result := new(PodsList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(PodsList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/pods_performance.go
+++ b/internal/rest-client/pods_performance.go
@@ -1,67 +1,66 @@
 package client
 
-
 type PodPerformance struct {
-	Id      string  `json:"id"`
-	Name      string  `json:"name"`
-	BytesPerMirroredWrite      float64  `json:"bytes_per_mirrored_write"`
-	BytesPerOp      float64  `json:"bytes_per_op"`
-	BytesPerRead      float64  `json:"bytes_per_read"`
-	BytesPerWrite      float64  `json:"bytes_per_write"`
-	MirroredWriteBytesPerSec      float64  `json:"mirrored_write_bytes_per_sec"`
-	MirroredWritesPerSec      float64  `json:"mirrored_writes_per_sec"`
-	QosRateLimitUsecPerMirroredWriteOp      float64  `json:"qos_rate_limit_usec_per_mirrored_write_op"`
-	QosRateLimitUsecPerReadOp      float64  `json:"qos_rate_limit_usec_per_read_op"`
-	QosRateLimitUsecPerWriteOp      float64  `json:"qos_rate_limit_usec_per_write_op"`
-	QueueUsecPerMirroredWriteOp      float64  `json:"queue_usec_per_mirrored_write_op"`
-	QueueUsecPerReadOp      float64  `json:"queue_usec_per_read_op"`
-	QueueUsecPerWriteOp      float64  `json:"queue_usec_per_write_op"`
-	ReadBytesPerSec      float64  `json:"read_bytes_per_sec"`
-	ReadsPerSec      float64  `json:"reads_per_sec"`
-	SanUsecPerMirroredWriteOp      float64  `json:"san_usec_per_mirrored_write_op"`
-	SanUsecPerReadOp      float64  `json:"san_usec_per_read_op"`
-	SanUsecPerWriteOp      float64  `json:"san_usec_per_write_op"`
-	ServiceUsecPerMirroredWriteOp      float64  `json:"service_usec_per_mirrored_write_op"`
-	ServiceUsecPerReadOp      float64  `json:"service_usec_per_read_op"`
-	ServiceUsecPerWriteOp      float64  `json:"service_usec_per_write_op"`
-	Time      int  `json:"time"`
-	UsecPerMirroredWriteOp      float64  `json:"usec_per_mirrored_write_op"`
-	UsecPerReadOp      float64  `json:"usec_per_read_op"`
-	UsecPerWriteOp      float64  `json:"usec_per_write_op"`
-	WriteBytesPerSec      float64  `json:"write_bytes_per_sec"`
-	WritesPerSec      float64  `json:"writes_per_sec"`
-	ServiceUsecPerReadOpCacheReduction      float64  `json:"service_usec_per_read_op_cache_reduction"`
-	OthersPerSec      float64  `json:"others_per_sec"`
-	UsecPerOtherOp      float64  `json:"usec_per_other_op"`
+	Id                                 string  `json:"id"`
+	Name                               string  `json:"name"`
+	BytesPerMirroredWrite              float64 `json:"bytes_per_mirrored_write"`
+	BytesPerOp                         float64 `json:"bytes_per_op"`
+	BytesPerRead                       float64 `json:"bytes_per_read"`
+	BytesPerWrite                      float64 `json:"bytes_per_write"`
+	MirroredWriteBytesPerSec           float64 `json:"mirrored_write_bytes_per_sec"`
+	MirroredWritesPerSec               float64 `json:"mirrored_writes_per_sec"`
+	QosRateLimitUsecPerMirroredWriteOp float64 `json:"qos_rate_limit_usec_per_mirrored_write_op"`
+	QosRateLimitUsecPerReadOp          float64 `json:"qos_rate_limit_usec_per_read_op"`
+	QosRateLimitUsecPerWriteOp         float64 `json:"qos_rate_limit_usec_per_write_op"`
+	QueueUsecPerMirroredWriteOp        float64 `json:"queue_usec_per_mirrored_write_op"`
+	QueueUsecPerReadOp                 float64 `json:"queue_usec_per_read_op"`
+	QueueUsecPerWriteOp                float64 `json:"queue_usec_per_write_op"`
+	ReadBytesPerSec                    float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec                        float64 `json:"reads_per_sec"`
+	SanUsecPerMirroredWriteOp          float64 `json:"san_usec_per_mirrored_write_op"`
+	SanUsecPerReadOp                   float64 `json:"san_usec_per_read_op"`
+	SanUsecPerWriteOp                  float64 `json:"san_usec_per_write_op"`
+	ServiceUsecPerMirroredWriteOp      float64 `json:"service_usec_per_mirrored_write_op"`
+	ServiceUsecPerReadOp               float64 `json:"service_usec_per_read_op"`
+	ServiceUsecPerWriteOp              float64 `json:"service_usec_per_write_op"`
+	Time                               int     `json:"time"`
+	UsecPerMirroredWriteOp             float64 `json:"usec_per_mirrored_write_op"`
+	UsecPerReadOp                      float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp                     float64 `json:"usec_per_write_op"`
+	WriteBytesPerSec                   float64 `json:"write_bytes_per_sec"`
+	WritesPerSec                       float64 `json:"writes_per_sec"`
+	ServiceUsecPerReadOpCacheReduction float64 `json:"service_usec_per_read_op_cache_reduction"`
+	OthersPerSec                       float64 `json:"others_per_sec"`
+	UsecPerOtherOp                     float64 `json:"usec_per_other_op"`
 }
 
 type PodsPerformanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []PodPerformance `json:"items"`
-        Total                []PodPerformance `json:"total"`
+	ContinuationToken  string           `json:"continuation_token"`
+	TotalItemCount     int              `json:"total_item_count"`
+	MoreItemsRemaining bool             `json:"more_items_remaining"`
+	Items              []PodPerformance `json:"items"`
+	Total              []PodPerformance `json:"total"`
 }
 
 func (fa *FAClient) GetPodsPerformance() *PodsPerformanceList {
 	uri := "/pods/performance"
-        result := new(PodsPerformanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(PodsPerformanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/pods_performance_replication.go
+++ b/internal/rest-client/pods_performance_replication.go
@@ -1,50 +1,48 @@
 package client
 
-
 type PerformanceReplication struct {
-	FromRemoteBytesPerSec    float64  `json:"from_remote_bytes_per_sec"`
-	ToRemoteBytesPerSec      float64  `json:"to_remote_bytes_per_sec"`
-	TotalBytesPerSec         float64  `json:"total_bytes_per_sec"`
+	FromRemoteBytesPerSec float64 `json:"from_remote_bytes_per_sec"`
+	ToRemoteBytesPerSec   float64 `json:"to_remote_bytes_per_sec"`
+	TotalBytesPerSec      float64 `json:"total_bytes_per_sec"`
 }
 
 type PodPerformanceReplication struct {
-	Pod       PodShort    `json:"pod"`
-	Time      int  `json:"time"`
-	ContinuousBytesPerSec    PerformanceReplication  `json:"continuous_bytes_per_sec"`
-	ResyncBytesPerSec        PerformanceReplication  `json:"resync_bytes_per_sec"`
-	SyncBytesPerSec          PerformanceReplication  `json:"sync_bytes_per_sec"`
-	PeriodicBytesPerSec      PerformanceReplication  `json:"periodic_bytes_per_sec"`
-	TotalBytesPerSec         float64                 `json:"total_bytes_per_sec"`
-
+	Pod                   PodShort               `json:"pod"`
+	Time                  int                    `json:"time"`
+	ContinuousBytesPerSec PerformanceReplication `json:"continuous_bytes_per_sec"`
+	ResyncBytesPerSec     PerformanceReplication `json:"resync_bytes_per_sec"`
+	SyncBytesPerSec       PerformanceReplication `json:"sync_bytes_per_sec"`
+	PeriodicBytesPerSec   PerformanceReplication `json:"periodic_bytes_per_sec"`
+	TotalBytesPerSec      float64                `json:"total_bytes_per_sec"`
 }
 
 type PodsPerformanceReplicationList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []PodPerformanceReplication `json:"items"`
-        Total                []PodPerformanceReplication `json:"total"`
+	ContinuationToken  string                      `json:"continuation_token"`
+	TotalItemCount     int                         `json:"total_item_count"`
+	MoreItemsRemaining bool                        `json:"more_items_remaining"`
+	Items              []PodPerformanceReplication `json:"items"`
+	Total              []PodPerformanceReplication `json:"total"`
 }
 
 func (fa *FAClient) GetPodsPerformanceReplication() *PodsPerformanceReplicationList {
 	uri := "/pods/performance/replication"
-        result := new(PodsPerformanceReplicationList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(PodsPerformanceReplicationList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/ports.go
+++ b/internal/rest-client/ports.go
@@ -22,18 +22,18 @@ func (fa *FAClient) GetPorts() *PortsList {
 	res, err := fa.RestClient.R().
 		SetResult(&result).
 		Get(uri)
-
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/subscriptions.go
+++ b/internal/rest-client/subscriptions.go
@@ -21,14 +21,15 @@ func (fa *FAClient) GetSubscriptions() *SubscriptionsList {
 	if err != nil {
 		fa.Error = err
 	}
+
 	if res.StatusCode() == 401 {
 		fa.RefreshSession()
-	}
-	res, err = fa.RestClient.R().
-		SetResult(&result).
-		Get(uri)
-	if err != nil {
-		fa.Error = err
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
 	}
 
 	return result

--- a/internal/rest-client/volumes.go
+++ b/internal/rest-client/volumes.go
@@ -1,74 +1,73 @@
 package client
 
-
-type Qos struct  {
-	BandwidthLimit  int   `json:"bandwidth_limit"`
-	IopsLimit       int   `json:"iops_limit"`
+type Qos struct {
+	BandwidthLimit int `json:"bandwidth_limit"`
+	IopsLimit      int `json:"iops_limit"`
 }
 
 type PriorityAdjustment struct {
-	PriorityAdjustmentOperator   int  `json:"priority_adjustment_operator"`
-	PriorityAdjustmentValue      int  `json:"priority_adjustment_value"`
+	PriorityAdjustmentOperator int `json:"priority_adjustment_operator"`
+	PriorityAdjustmentValue    int `json:"priority_adjustment_value"`
 }
 
 type Source struct {
-	Id      string     `json:"id"`
-	Name    string     `json:"name"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type VolumeGroupShort struct {
-	Id      string     `json:"id"`
-	Name    string     `json:"name"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type Volume struct {
-	Id                       string              `json:"id"`
-	Name                     string              `json:"name"`
-	ConnectionCount          int                 `json:"connection_count"`
-	Created                  int                 `json:"created"`
-	Destroyed                bool                `json:"destroyed"`
-	HostEncryptionKeyStatus  string              `json:"host_encryption_key_status"`
-	PriorityAdjustment       PriorityAdjustment  `json:"priority_adjustment"`
-	Provisioned              int                 `json:"provisioned"`
-	Serial                   string              `json:"serial"`
-	Space                    Space               `json:"space"`
-	TimeRemaining            int                 `json:"time_remaining"`
-	Pod                      PodShort            `json:"pod"`
-	Source                   Source              `json:"source"`
-	Subtype                  string              `json:"subtype"`
-	VolumeGroup              VolumeGroupShort    `json:"volume_group"`
-	RequestedPromotionState  string              `json:"requested_promotion_state"`
-	PromotionStatus          string              `json:"promotion_status"`
-	Priority                 int                 `json:"priority"`
+	Id                      string             `json:"id"`
+	Name                    string             `json:"name"`
+	ConnectionCount         int                `json:"connection_count"`
+	Created                 int                `json:"created"`
+	Destroyed               bool               `json:"destroyed"`
+	HostEncryptionKeyStatus string             `json:"host_encryption_key_status"`
+	PriorityAdjustment      PriorityAdjustment `json:"priority_adjustment"`
+	Provisioned             int                `json:"provisioned"`
+	Serial                  string             `json:"serial"`
+	Space                   Space              `json:"space"`
+	TimeRemaining           int                `json:"time_remaining"`
+	Pod                     PodShort           `json:"pod"`
+	Source                  Source             `json:"source"`
+	Subtype                 string             `json:"subtype"`
+	VolumeGroup             VolumeGroupShort   `json:"volume_group"`
+	RequestedPromotionState string             `json:"requested_promotion_state"`
+	PromotionStatus         string             `json:"promotion_status"`
+	Priority                int                `json:"priority"`
 }
 
 type VolumesList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []Volume `json:"items"`
-        Total                []Volume `json:"total"`
+	ContinuationToken  string   `json:"continuation_token"`
+	TotalItemCount     int      `json:"total_item_count"`
+	MoreItemsRemaining bool     `json:"more_items_remaining"`
+	Items              []Volume `json:"items"`
+	Total              []Volume `json:"total"`
 }
 
 func (fa *FAClient) GetVolumes() *VolumesList {
 	uri := "/volumes"
-        result := new(VolumesList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(VolumesList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }

--- a/internal/rest-client/volumes_performance.go
+++ b/internal/rest-client/volumes_performance.go
@@ -1,65 +1,64 @@
 package client
 
-
 type VolumePerformance struct {
-	Id      string  `json:"id"`
-	Name      string  `json:"name"`
-	BytesPerMirroredWrite      float64  `json:"bytes_per_mirrored_write"`
-	BytesPerOp      float64  `json:"bytes_per_op"`
-	BytesPerRead      float64  `json:"bytes_per_read"`
-	BytesPerWrite      float64  `json:"bytes_per_write"`
-	MirroredWriteBytesPerSec      float64  `json:"mirrored_write_bytes_per_sec"`
-	MirroredWritesPerSec      float64  `json:"mirrored_writes_per_sec"`
-	QosRateLimitUsecPerMirroredWriteOp      float64  `json:"qos_rate_limit_usec_per_mirrored_write_op"`
-	QosRateLimitUsecPerReadOp      float64  `json:"qos_rate_limit_usec_per_read_op"`
-	QosRateLimitUsecPerWriteOp      float64  `json:"qos_rate_limit_usec_per_write_op"`
-	QueueUsecPerMirroredWriteOp      float64  `json:"queue_usec_per_mirrored_write_op"`
-	QueueUsecPerReadOp      float64  `json:"queue_usec_per_read_op"`
-	QueueUsecPerWriteOp      float64  `json:"queue_usec_per_write_op"`
-	ReadBytesPerSec      float64  `json:"read_bytes_per_sec"`
-	ReadsPerSec      float64  `json:"reads_per_sec"`
-	SanUsecPerMirroredWriteOp      float64  `json:"san_usec_per_mirrored_write_op"`
-	SanUsecPerReadOp      float64  `json:"san_usec_per_read_op"`
-	SanUsecPerWriteOp      float64  `json:"san_usec_per_write_op"`
-	ServiceUsecPerMirroredWriteOp      float64  `json:"service_usec_per_mirrored_write_op"`
-	ServiceUsecPerReadOp      float64  `json:"service_usec_per_read_op"`
-	ServiceUsecPerWriteOp      float64  `json:"service_usec_per_write_op"`
-	Time      int  `json:"time"`
-	UsecPerMirroredWriteOp      float64  `json:"usec_per_mirrored_write_op"`
-	UsecPerReadOp      float64  `json:"usec_per_read_op"`
-	UsecPerWriteOp      float64  `json:"usec_per_write_op"`
-	WriteBytesPerSec      float64  `json:"write_bytes_per_sec"`
-	WritesPerSec      float64  `json:"writes_per_sec"`
-	ServiceUsecPerReadOpCacheReduction      float64  `json:"service_usec_per_read_op_cache_reduction"`
+	Id                                 string  `json:"id"`
+	Name                               string  `json:"name"`
+	BytesPerMirroredWrite              float64 `json:"bytes_per_mirrored_write"`
+	BytesPerOp                         float64 `json:"bytes_per_op"`
+	BytesPerRead                       float64 `json:"bytes_per_read"`
+	BytesPerWrite                      float64 `json:"bytes_per_write"`
+	MirroredWriteBytesPerSec           float64 `json:"mirrored_write_bytes_per_sec"`
+	MirroredWritesPerSec               float64 `json:"mirrored_writes_per_sec"`
+	QosRateLimitUsecPerMirroredWriteOp float64 `json:"qos_rate_limit_usec_per_mirrored_write_op"`
+	QosRateLimitUsecPerReadOp          float64 `json:"qos_rate_limit_usec_per_read_op"`
+	QosRateLimitUsecPerWriteOp         float64 `json:"qos_rate_limit_usec_per_write_op"`
+	QueueUsecPerMirroredWriteOp        float64 `json:"queue_usec_per_mirrored_write_op"`
+	QueueUsecPerReadOp                 float64 `json:"queue_usec_per_read_op"`
+	QueueUsecPerWriteOp                float64 `json:"queue_usec_per_write_op"`
+	ReadBytesPerSec                    float64 `json:"read_bytes_per_sec"`
+	ReadsPerSec                        float64 `json:"reads_per_sec"`
+	SanUsecPerMirroredWriteOp          float64 `json:"san_usec_per_mirrored_write_op"`
+	SanUsecPerReadOp                   float64 `json:"san_usec_per_read_op"`
+	SanUsecPerWriteOp                  float64 `json:"san_usec_per_write_op"`
+	ServiceUsecPerMirroredWriteOp      float64 `json:"service_usec_per_mirrored_write_op"`
+	ServiceUsecPerReadOp               float64 `json:"service_usec_per_read_op"`
+	ServiceUsecPerWriteOp              float64 `json:"service_usec_per_write_op"`
+	Time                               int     `json:"time"`
+	UsecPerMirroredWriteOp             float64 `json:"usec_per_mirrored_write_op"`
+	UsecPerReadOp                      float64 `json:"usec_per_read_op"`
+	UsecPerWriteOp                     float64 `json:"usec_per_write_op"`
+	WriteBytesPerSec                   float64 `json:"write_bytes_per_sec"`
+	WritesPerSec                       float64 `json:"writes_per_sec"`
+	ServiceUsecPerReadOpCacheReduction float64 `json:"service_usec_per_read_op_cache_reduction"`
 }
 
 type VolumesPerformanceList struct {
-        ContinuationToken    string   `json:"continuation_token"`
-        TotalItemCount       int      `json:"total_item_count"`
-        MoreItemsRemaining   bool     `json:"more_items_remaining"`
-        Items                []VolumePerformance `json:"items"`
-        Total                []VolumePerformance `json:"total"`
+	ContinuationToken  string              `json:"continuation_token"`
+	TotalItemCount     int                 `json:"total_item_count"`
+	MoreItemsRemaining bool                `json:"more_items_remaining"`
+	Items              []VolumePerformance `json:"items"`
+	Total              []VolumePerformance `json:"total"`
 }
 
 func (fa *FAClient) GetVolumesPerformance() *VolumesPerformanceList {
 	uri := "/volumes/performance"
-        result := new(VolumesPerformanceList)
-        res, err := fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
+	result := new(VolumesPerformanceList)
+	res, err := fa.RestClient.R().
+		SetResult(&result).
+		Get(uri)
+	if err != nil {
+		fa.Error = err
+	}
 
-        if err != nil {
-                fa.Error = err
-        }
-        if res.StatusCode() == 401 {
-                fa.RefreshSession()
-        }
-        res, err = fa.RestClient.R().
-                SetResult(&result).
-                Get(uri)
-        if err != nil {
-                fa.Error = err
-        }
+	if res.StatusCode() == 401 {
+		fa.RefreshSession()
+		_, err = fa.RestClient.R().
+			SetResult(&result).
+			Get(uri)
+		if err != nil {
+			fa.Error = err
+		}
+	}
 
-        return result
+	return result
 }


### PR DESCRIPTION
See stacktrace

````
2023/11/01 14:17:20 Start Pure FlashArray exporter v1.0.9 on 0.0.0.0:9490
fatal error: concurrent map writes

goroutine 317 [running]:
net/textproto.MIMEHeader.Set(...)
	/usr/local/go/src/net/textproto/header.go:22
net/http.Header.Set(...)
	/usr/local/go/src/net/http/header.go:40
github.com/go-resty/resty/v2.(*Client).SetHeader(...)
	/Users/jlaing/go/pkg/mod/github.com/go-resty/resty/v2@v2.7.0/client.go:195
purestorage/fa-openmetrics-exporter/internal/rest-client.(*FAClient).RefreshSession(0x14000397440)
	/Users/jlaing/git/pure/pure-fa-openmetrics-exporter/internal/rest-client/flasharray_client.go:119 +0x3f0
purestorage/fa-openmetrics-exporter/internal/rest-client.(*FAClient).GetHardware(0x14000397440)
	/Users/jlaing/git/pure/pure-fa-openmetrics-exporter/internal/rest-client/hardware.go:36 +0x2d0
purestorage/fa-openmetrics-exporter/internal/openmetrics-exporter.(*HardwareCollector).Collect(0x1400006a8c0, 0x140004b2f58?)
	/Users/jlaing/git/pure/pure-fa-openmetrics-exporter/internal/openmetrics-exporter/hardware_collector.go:21 +0x34
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/Users/jlaing/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:457 +0xc0
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/Users/jlaing/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:547 +0x9f4
````

This is the interesting line
````
	/Users/jlaing/go/pkg/mod/github.com/go-resty/resty/v2@v2.7.0/client.go:195
purestorage/fa-openmetrics-exporter/internal/rest-client.(*FAClient).RefreshSession(0x14000397440)
````

currently on all the internal/rest-client/[uri].go files, there is some error handling on if a 401 error is encountered. 

it currently stands like this

 ````
	if res.StatusCode() == 401 {
		fa.RefreshSession()
	}
	res, err = fa.RestClient.R().
		SetResult(&result).
		Get(uri)
	if err != nil {
		fa.Error = err
        }
````

This could definitely cause the concurrent map write since the rest of the code that is supposed to be in the `if` is running out of the `if`.

The closing bracket needs to be moved to the end of the error handling statement ( see #117 ) to correctly handle the error like such, also the var res needs to be _ because its never used after that statement. 

 ````
	if res.StatusCode() == 401 {
		fa.RefreshSession()
		_, err = fa.RestClient.R().
			SetResult(&result).
			Get(uri)
		if err != nil {
			fa.Error = err
		}
        }
````