### PR TITLE
Handle null json objects for Space structs

### DIFF
--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -23,95 +23,126 @@ func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	a := arrays.Items[0]
-	ch <- prometheus.MustNewConstMetric(
-		c.ReductionDesc,
-		prometheus.GaugeValue,
-		a.Space.DataReduction,
-	)
+
+	if a.Space.DataReduction != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.ReductionDesc,
+			prometheus.GaugeValue,
+			*a.Space.DataReduction,
+		)
+	}
 	ch <- prometheus.MustNewConstMetric(
 		c.SpaceDesc,
 		prometheus.GaugeValue,
 		a.Capacity, "capacity",
 	)
+	if a.Space.Shared != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.Shared), "shared",
+		)
+	}
+	if a.Space.Snapshots != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.Snapshots), "snapshots",
+		)
+	}
+	if a.Space.System != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.System), "system",
+		)
+	}
+	if a.Space.ThinProvisioning != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			*a.Space.ThinProvisioning, "thin_provisioning",
+		)
+	}
+	if a.Space.TotalPhysical != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.TotalPhysical), "total_physical",
+		)
+	}
+	if a.Space.TotalProvisioned != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.TotalProvisioned), "total_provisioned",
+		)
+	}
+	if a.Space.TotalReduction != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			*a.Space.TotalReduction, "total_reduction",
+		)
+	}
+	if a.Space.Unique != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.Unique), "unique",
+		)
+	}
+	if a.Space.Virtual != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.Virtual), "virtual",
+		)
+	}
+	if a.Space.Replication != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.Replication), "replication",
+		)
+	}
+	if a.Space.SharedEffective != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.SharedEffective), "shared_effective",
+		)
+	}
+	if a.Space.SnapshotsEffective != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.SnapshotsEffective), "snapshots_effective",
+		)
+	}
+	if a.Space.UniqueEffective != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.UniqueEffective), "unique_effective",
+		)
+	}
+	if a.Space.TotalEffective != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.SpaceDesc,
+			prometheus.GaugeValue,
+			float64(*a.Space.TotalEffective), "total_effective",
+		)
+	}
 	ch <- prometheus.MustNewConstMetric(
 		c.SpaceDesc,
 		prometheus.GaugeValue,
-		a.Space.Shared, "shared",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.Snapshots, "snapshots",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.System, "system",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.ThinProvisioning, "thin_provisioning",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.TotalPhysical, "total_physical",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.TotalProvisioned, "total_provisioned",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.TotalReduction, "total_reduction",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.Unique, "unique",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.Virtual, "virtual",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.Replication, "replication",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.SharedEffective, "shared_effective",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.SnapshotsEffective, "snapshots_effective",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.UniqueEffective, "unique_effective",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Space.TotalEffective, "total_effective",
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.SpaceDesc,
-		prometheus.GaugeValue,
-		a.Capacity-a.Space.System-a.Space.Replication-a.Space.Shared-a.Space.Snapshots-a.Space.Unique, "empty",
+		a.Capacity-(float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique)), "empty",
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.UtilizationDesc,
 		prometheus.GaugeValue,
-		(a.Space.System+a.Space.Replication+a.Space.Shared+a.Space.Snapshots+a.Space.Unique)/a.Capacity*100,
+		(float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique))/a.Capacity*100,
 	)
 }
 

--- a/internal/openmetrics-exporter/arrays_space_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_space_collector_test.go
@@ -37,24 +37,54 @@ func TestArraySpaceCollector(t *testing.T) {
 	want := make(map[string]bool)
 	a := arrs.Items[0]
 	sp := arrs.Items[0].Space
-	want[fmt.Sprintf("gauge:{value:%g}", sp.DataReduction)] = true
+	if sp.DataReduction != nil {
+		want[fmt.Sprintf("gauge:{value:%g}", *sp.DataReduction)] = true
+	}
 	want[fmt.Sprintf("label:{name:\"space\" value:\"capacity\"} gauge:{value:%g}", a.Capacity)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", sp.Shared)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", sp.Snapshots)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"system\"} gauge:{value:%g}", sp.System)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", sp.ThinProvisioning)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", sp.TotalPhysical)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", sp.TotalProvisioned)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", sp.TotalReduction)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", sp.Unique)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", sp.Virtual)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", sp.Replication)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", sp.SharedEffective)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", sp.SnapshotsEffective)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", sp.UniqueEffective)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", sp.TotalEffective)] = true
-	want[fmt.Sprintf("label:{name:\"space\" value:\"empty\"} gauge:{value:%g}", a.Capacity-a.Space.System-a.Space.Replication-a.Space.Shared-a.Space.Snapshots-a.Space.Unique)] = true
-	want[fmt.Sprintf("gauge:{value:%g}", (a.Space.System+a.Space.Replication+a.Space.Shared+a.Space.Snapshots+a.Space.Unique)/a.Capacity*100)] = true
+	if sp.Shared != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", float64(*sp.Shared))] = true
+	}
+	if sp.Snapshots != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", float64(*sp.Snapshots))] = true
+	}
+	if sp.System != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"system\"} gauge:{value:%g}", float64(*sp.System))] = true
+	}
+	if sp.ThinProvisioning != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", *sp.ThinProvisioning)] = true
+	}
+	if sp.TotalPhysical != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", float64(*sp.TotalPhysical))] = true
+	}
+	if sp.TotalProvisioned != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", float64(*sp.TotalProvisioned))] = true
+	}
+	if sp.TotalReduction != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", *sp.TotalReduction)] = true
+	}
+	if sp.Unique != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", float64(*sp.Unique))] = true
+	}
+	if sp.Virtual != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", float64(*sp.Virtual))] = true
+	}
+	if sp.Replication != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", float64(*sp.Replication))] = true
+	}
+	if sp.SharedEffective != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", float64(*sp.SharedEffective))] = true
+	}
+	if sp.SnapshotsEffective != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", float64(*sp.SnapshotsEffective))] = true
+	}
+	if sp.UniqueEffective != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", float64(*sp.UniqueEffective))] = true
+	}
+	if sp.TotalEffective != nil {
+		want[fmt.Sprintf("label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", float64(*sp.TotalEffective))] = true
+	}
+	want[fmt.Sprintf("label:{name:\"space\" value:\"empty\"} gauge:{value:%g}", a.Capacity-(float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique)))] = true
+	want[fmt.Sprintf("gauge:{value:%g}", (float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique))/a.Capacity*100)] = true
 	defer server.Close()
 	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
 	ac := NewArraySpaceCollector(c)

--- a/internal/openmetrics-exporter/dirs_space_collector.go
+++ b/internal/openmetrics-exporter/dirs_space_collector.go
@@ -1,9 +1,9 @@
 package collectors
 
-
 import (
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 type DirectoriesSpaceCollector struct {
@@ -22,97 +22,128 @@ func (c *DirectoriesSpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, d := range dirs.Items {
-		ch <- prometheus.MustNewConstMetric(
-			c.ReductionDesc,
-			prometheus.GaugeValue,
-			d.Space.DataReduction,
-			d.Name,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.Shared,
-			d.Name, "shared",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.Snapshots,
-			d.Name, "snapshots",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.System,
-			d.Name, "system",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.ThinProvisioning,
-			d.Name, "thin_provisioning",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.TotalPhysical,
-			d.Name, "total_physical",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.TotalProvisioned,
-			d.Name, "total_provisioned",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.TotalReduction,
-			d.Name, "total_reduction",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.Unique,
-			d.Name, "unique",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.Virtual,
-			d.Name, "virtual",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.Replication,
-			d.Name, "replication",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.SharedEffective,
-			d.Name, "shared_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.SnapshotsEffective,
-			d.Name, "snapshots_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.UniqueEffective,
-			d.Name, "unique_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			d.Space.TotalEffective,
-			d.Name, "total_effective",
-		)
-        }
+
+		if d.Space.DataReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.ReductionDesc,
+				prometheus.GaugeValue,
+				*d.Space.DataReduction,
+				d.Name,
+			)
+		}
+		if d.Space.Shared != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.Shared),
+				d.Name, "shared",
+			)
+		}
+		if d.Space.Snapshots != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.Snapshots),
+				d.Name, "snapshots",
+			)
+		}
+		if d.Space.System != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.System),
+				d.Name, "system",
+			)
+		}
+		if d.Space.ThinProvisioning != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*d.Space.ThinProvisioning,
+				d.Name, "thin_provisioning",
+			)
+		}
+		if d.Space.TotalPhysical != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.TotalPhysical),
+				d.Name, "total_physical",
+			)
+		}
+		if d.Space.TotalProvisioned != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.TotalProvisioned),
+				d.Name, "total_provisioned",
+			)
+		}
+		if d.Space.TotalReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*d.Space.TotalReduction,
+				d.Name, "total_reduction",
+			)
+		}
+		if d.Space.Unique != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.Unique),
+				d.Name, "unique",
+			)
+		}
+		if d.Space.Virtual != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.Virtual),
+				d.Name, "virtual",
+			)
+		}
+		if d.Space.Replication != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.Replication),
+				d.Name, "replication",
+			)
+		}
+		if d.Space.SharedEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.SharedEffective),
+				d.Name, "shared_effective",
+			)
+		}
+		if d.Space.SnapshotsEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.SnapshotsEffective),
+				d.Name, "snapshots_effective",
+			)
+		}
+		if d.Space.UniqueEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.UniqueEffective),
+				d.Name, "unique_effective",
+			)
+		}
+		if d.Space.TotalEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*d.Space.TotalEffective),
+				d.Name, "total_effective",
+			)
+		}
+	}
 }
 
 func NewDirectoriesSpaceCollector(fa *client.FAClient) *DirectoriesSpaceCollector {

--- a/internal/openmetrics-exporter/dirs_space_collector_test.go
+++ b/internal/openmetrics-exporter/dirs_space_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestDirectoriesSpaceCollector(t *testing.T) {
@@ -23,35 +22,65 @@ func TestDirectoriesSpaceCollector(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/directories$`)
 		if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
 		} else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
 		}
-	    }))
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	want := make(map[string]bool)
 	for _, d := range directories.Items {
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", d.Name, d.Space.DataReduction)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", d.Name, d.Space.Shared)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", d.Name, d.Space.Snapshots)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", d.Name, d.Space.System)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", d.Name, d.Space.ThinProvisioning)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", d.Name, d.Space.TotalPhysical)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", d.Name, d.Space.TotalProvisioned)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", d.Name, d.Space.TotalReduction)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", d.Name, d.Space.Unique)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", d.Name, d.Space.Virtual)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", d.Name, d.Space.Replication)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", d.Name, d.Space.SharedEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", d.Name, d.Space.SnapshotsEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", d.Name, d.Space.UniqueEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", d.Name, d.Space.TotalEffective)] = true
+		if d.Space.DataReduction != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", d.Name, *d.Space.DataReduction)] = true
+		}
+		if d.Space.Shared != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", d.Name, float64(*d.Space.Shared))] = true
+		}
+		if d.Space.Snapshots != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", d.Name, float64(*d.Space.Snapshots))] = true
+		}
+		if d.Space.System != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", d.Name, float64(*d.Space.System))] = true
+		}
+		if d.Space.ThinProvisioning != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", d.Name, *d.Space.ThinProvisioning)] = true
+		}
+		if d.Space.TotalPhysical != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", d.Name, float64(*d.Space.TotalPhysical))] = true
+		}
+		if d.Space.TotalProvisioned != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", d.Name, float64(*d.Space.TotalProvisioned))] = true
+		}
+		if d.Space.TotalReduction != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", d.Name, *d.Space.TotalReduction)] = true
+		}
+		if d.Space.Unique != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", d.Name, float64(*d.Space.Unique))] = true
+		}
+		if d.Space.Virtual != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", d.Name, float64(*d.Space.Virtual))] = true
+		}
+		if d.Space.Replication != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", d.Name, float64(*d.Space.Replication))] = true
+		}
+		if d.Space.SharedEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", d.Name, float64(*d.Space.SharedEffective))] = true
+		}
+		if d.Space.UniqueEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", d.Name, float64(*d.Space.SnapshotsEffective))] = true
+		}
+		if d.Space.UniqueEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", d.Name, float64(*d.Space.UniqueEffective))] = true
+		}
+		if d.Space.TotalEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", d.Name, float64(*d.Space.TotalEffective))] = true
+		}
 	}
 	defer server.Close()
 	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)

--- a/internal/openmetrics-exporter/hosts_space_collector.go
+++ b/internal/openmetrics-exporter/hosts_space_collector.go
@@ -23,96 +23,126 @@ func (c *HostsSpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, h := range hosts.Items {
-		ch <- prometheus.MustNewConstMetric(
-			c.ReductionDesc,
-			prometheus.GaugeValue,
-			h.Space.DataReduction,
-			h.Name,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Shared,
-			h.Name, "shared",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Snapshots,
-			h.Name, "snapshots",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.System,
-			h.Name, "system",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.ThinProvisioning,
-			h.Name, "thin_provisioning",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalPhysical,
-			h.Name, "total_physical",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalProvisioned,
-			h.Name, "total_provisioned",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalReduction,
-			h.Name, "total_reduction",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Unique,
-			h.Name, "unique",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Virtual,
-			h.Name, "virtual",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Replication,
-			h.Name, "replication",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.SharedEffective,
-			h.Name, "shared_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.SnapshotsEffective,
-			h.Name, "snapshots_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.UniqueEffective,
-			h.Name, "unique_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalEffective,
-			h.Name, "total_effective",
-		)
+		if h.Space.DataReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.ReductionDesc,
+				prometheus.GaugeValue,
+				*h.Space.DataReduction,
+				h.Name,
+			)
+		}
+		if h.Space.Shared != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Shared),
+				h.Name, "shared",
+			)
+		}
+		if h.Space.Snapshots != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Snapshots),
+				h.Name, "snapshots",
+			)
+		}
+		if h.Space.System != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.System),
+				h.Name, "system",
+			)
+		}
+		if h.Space.ThinProvisioning != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*h.Space.ThinProvisioning,
+				h.Name, "thin_provisioning",
+			)
+		}
+		if h.Space.TotalPhysical != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalPhysical),
+				h.Name, "total_physical",
+			)
+		}
+		if h.Space.TotalProvisioned != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalProvisioned),
+				h.Name, "total_provisioned",
+			)
+		}
+		if h.Space.TotalReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*h.Space.TotalReduction,
+				h.Name, "total_reduction",
+			)
+		}
+		if h.Space.Unique != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Unique),
+				h.Name, "unique",
+			)
+		}
+		if h.Space.Virtual != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Virtual),
+				h.Name, "virtual",
+			)
+		}
+		if h.Space.Replication != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Replication),
+				h.Name, "replication",
+			)
+		}
+		if h.Space.SharedEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.SharedEffective),
+				h.Name, "shared_effective",
+			)
+		}
+		if h.Space.SnapshotsEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.SnapshotsEffective),
+				h.Name, "snapshots_effective",
+			)
+		}
+		if h.Space.UniqueEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.UniqueEffective),
+				h.Name, "unique_effective",
+			)
+		}
+		if h.Space.TotalEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalEffective),
+				h.Name, "total_effective",
+			)
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.ConnectivityDesc,
 			prometheus.GaugeValue,

--- a/internal/openmetrics-exporter/hosts_space_collector_test.go
+++ b/internal/openmetrics-exporter/hosts_space_collector_test.go
@@ -36,21 +36,51 @@ func TestHostsSpaceCollector(t *testing.T) {
 	e := endp[len(endp)-1]
 	want := make(map[string]bool)
 	for _, h := range hosts.Items {
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", h.Name, h.Space.DataReduction)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", h.Name, h.Space.Shared)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", h.Name, h.Space.Snapshots)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", h.Name, h.Space.System)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", h.Name, h.Space.ThinProvisioning)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", h.Name, h.Space.TotalPhysical)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", h.Name, h.Space.TotalProvisioned)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", h.Name, h.Space.TotalReduction)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", h.Name, h.Space.Unique)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", h.Name, h.Space.Virtual)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", h.Name, h.Space.Replication)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", h.Name, h.Space.SharedEffective)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", h.Name, h.Space.SnapshotsEffective)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", h.Name, h.Space.UniqueEffective)] = true
-		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", h.Name, h.Space.TotalEffective)] = true
+		if h.Space.DataReduction != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", h.Name, *h.Space.DataReduction)] = true
+		}
+		if h.Space.Shared != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", h.Name, float64(*h.Space.Shared))] = true
+		}
+		if h.Space.Snapshots != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", h.Name, float64(*h.Space.Snapshots))] = true
+		}
+		if h.Space.System != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", h.Name, float64(*h.Space.System))] = true
+		}
+		if h.Space.ThinProvisioning != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", h.Name, *h.Space.ThinProvisioning)] = true
+		}
+		if h.Space.TotalPhysical != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", h.Name, float64(*h.Space.TotalPhysical))] = true
+		}
+		if h.Space.TotalProvisioned != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", h.Name, float64(*h.Space.TotalProvisioned))] = true
+		}
+		if h.Space.TotalReduction != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", h.Name, *h.Space.TotalReduction)] = true
+		}
+		if h.Space.Unique != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", h.Name, float64(*h.Space.Unique))] = true
+		}
+		if h.Space.Virtual != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", h.Name, float64(*h.Space.Virtual))] = true
+		}
+		if h.Space.Replication != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", h.Name, float64(*h.Space.Replication))] = true
+		}
+		if h.Space.SharedEffective != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", h.Name, float64(*h.Space.SharedEffective))] = true
+		}
+		if h.Space.SnapshotsEffective != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", h.Name, float64(*h.Space.SnapshotsEffective))] = true
+		}
+		if h.Space.UniqueEffective != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", h.Name, float64(*h.Space.UniqueEffective))] = true
+		}
+		if h.Space.TotalEffective != nil {
+			want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", h.Name, float64(*h.Space.TotalEffective))] = true
+		}
 		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"details\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:1}", h.Name, h.PortConnectivity.Details, h.PortConnectivity.Status)] = true
 	}
 	defer server.Close()

--- a/internal/openmetrics-exporter/pods_space_collector.go
+++ b/internal/openmetrics-exporter/pods_space_collector.go
@@ -1,9 +1,9 @@
 package collectors
 
-
 import (
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 type PodsSpaceCollector struct {
@@ -24,96 +24,126 @@ func (c *PodsSpaceCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	for _, h := range pods.Items {
 		var s float64
-		ch <- prometheus.MustNewConstMetric(
-			c.ReductionDesc,
-			prometheus.GaugeValue,
-			h.Space.DataReduction,
-			h.Name,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Shared,
-			h.Name, "shared",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Snapshots,
-			h.Name, "snapshots",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.System,
-			h.Name, "system",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.ThinProvisioning,
-			h.Name, "thin_provisioning",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalPhysical,
-			h.Name, "total_physical",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalProvisioned,
-			h.Name, "total_provisioned",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalReduction,
-			h.Name, "total_reduction",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Unique,
-			h.Name, "unique",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Virtual,
-			h.Name, "virtual",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.Replication,
-			h.Name, "replication",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.SharedEffective,
-			h.Name, "shared_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.SnapshotsEffective,
-			h.Name, "snapshots_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.UniqueEffective,
-			h.Name, "unique_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			h.Space.TotalEffective,
-			h.Name, "total_effective",
-		)
+		if h.Space.DataReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.ReductionDesc,
+				prometheus.GaugeValue,
+				*h.Space.DataReduction,
+				h.Name,
+			)
+		}
+		if h.Space.Shared != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Shared),
+				h.Name, "shared",
+			)
+		}
+		if h.Space.Snapshots != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Snapshots),
+				h.Name, "snapshots",
+			)
+		}
+		if h.Space.System != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.System),
+				h.Name, "system",
+			)
+		}
+		if h.Space.ThinProvisioning != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*h.Space.ThinProvisioning,
+				h.Name, "thin_provisioning",
+			)
+		}
+		if h.Space.TotalPhysical != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalPhysical),
+				h.Name, "total_physical",
+			)
+		}
+		if h.Space.TotalProvisioned != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalProvisioned),
+				h.Name, "total_provisioned",
+			)
+		}
+		if h.Space.TotalReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*h.Space.TotalReduction,
+				h.Name, "total_reduction",
+			)
+		}
+		if h.Space.Unique != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Unique),
+				h.Name, "unique",
+			)
+		}
+		if h.Space.Virtual != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Virtual),
+				h.Name, "virtual",
+			)
+		}
+		if h.Space.Replication != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.Replication),
+				h.Name, "replication",
+			)
+		}
+		if h.Space.SharedEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.SharedEffective),
+				h.Name, "shared_effective",
+			)
+		}
+		if h.Space.SnapshotsEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.SnapshotsEffective),
+				h.Name, "snapshots_effective",
+			)
+		}
+		if h.Space.UniqueEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.UniqueEffective),
+				h.Name, "unique_effective",
+			)
+		}
+		if h.Space.TotalEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*h.Space.TotalEffective),
+				h.Name, "total_effective",
+			)
+		}
 		for _, a := range h.Arrays {
 			if a.MediatorStatus == "online" {
 				s = 1
@@ -127,7 +157,7 @@ func (c *PodsSpaceCollector) Collect(ch chan<- prometheus.Metric) {
 				a.Name, h.Mediator, h.Name, a.MediatorStatus,
 			)
 		}
-        }
+	}
 }
 
 func NewPodsSpaceCollector(fa *client.FAClient) *PodsSpaceCollector {

--- a/internal/openmetrics-exporter/pods_space_collector_test.go
+++ b/internal/openmetrics-exporter/pods_space_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestPodsSpaceCollector(t *testing.T) {
@@ -23,42 +22,72 @@ func TestPodsSpaceCollector(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pods$`)
 		if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
 		} else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
 		}
-	    }))
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	want := make(map[string]bool)
 	for _, p := range pods.Items {
 		var s float64
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.Space.DataReduction)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", p.Name, p.Space.Shared)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", p.Name, p.Space.Snapshots)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", p.Name, p.Space.System)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", p.Name, p.Space.ThinProvisioning)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", p.Name, p.Space.TotalPhysical)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", p.Name, p.Space.TotalProvisioned)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", p.Name, p.Space.TotalReduction)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", p.Name, p.Space.Unique)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", p.Name, p.Space.Virtual)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", p.Name, p.Space.Replication)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", p.Name, p.Space.SharedEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", p.Name, p.Space.SnapshotsEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", p.Name, p.Space.UniqueEffective)] = true
-		want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", p.Name, p.Space.TotalEffective)] = true
+		if p.Space.DataReduction != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, *p.Space.DataReduction)] = true
+		}
+		if p.Space.Shared != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} gauge:{value:%g}", p.Name, float64(*p.Space.Shared))] = true
+		}
+		if p.Space.Snapshots != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} gauge:{value:%g}", p.Name, float64(*p.Space.Snapshots))] = true
+		}
+		if p.Space.System != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"system\"} gauge:{value:%g}", p.Name, float64(*p.Space.System))] = true
+		}
+		if p.Space.ThinProvisioning != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} gauge:{value:%g}", p.Name, *p.Space.ThinProvisioning)] = true
+		}
+		if p.Space.TotalPhysical != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} gauge:{value:%g}", p.Name, float64(*p.Space.TotalPhysical))] = true
+		}
+		if p.Space.TotalProvisioned != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} gauge:{value:%g}", p.Name, float64(*p.Space.TotalProvisioned))] = true
+		}
+		if p.Space.TotalReduction != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} gauge:{value:%g}", p.Name, *p.Space.TotalReduction)] = true
+		}
+		if p.Space.Unique != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} gauge:{value:%g}", p.Name, float64(*p.Space.Unique))] = true
+		}
+		if p.Space.Virtual != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} gauge:{value:%g}", p.Name, float64(*p.Space.Virtual))] = true
+		}
+		if p.Space.Replication != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} gauge:{value:%g}", p.Name, float64(*p.Space.Replication))] = true
+		}
+		if p.Space.SharedEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} gauge:{value:%g}", p.Name, float64(*p.Space.SharedEffective))] = true
+		}
+		if p.Space.SnapshotsEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} gauge:{value:%g}", p.Name, float64(*p.Space.SnapshotsEffective))] = true
+		}
+		if p.Space.UniqueEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} gauge:{value:%g}", p.Name, float64(*p.Space.UniqueEffective))] = true
+		}
+		if p.Space.TotalEffective != nil {
+			want[fmt.Sprintf("label:{name:\"name\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} gauge:{value:%g}", p.Name, float64(*p.Space.TotalEffective))] = true
+		}
 		for _, a := range p.Arrays {
-                        if a.MediatorStatus == "online" {
-                                s = 1
-                        } else {
-                                s = 0
-                        }
+			if a.MediatorStatus == "online" {
+				s = 1
+			} else {
+				s = 0
+			}
 			want[fmt.Sprintf("label:{name:\"array\" value:\"%s\"} label:{name:\"mediator\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", a.Name, p.Mediator, p.Name, a.MediatorStatus, s)] = true
 		}
 	}

--- a/internal/openmetrics-exporter/volumes_space_collector.go
+++ b/internal/openmetrics-exporter/volumes_space_collector.go
@@ -1,9 +1,9 @@
 package collectors
 
-
 import (
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 type VolumesSpaceCollector struct {
@@ -23,97 +23,127 @@ func (c *VolumesSpaceCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	for _, v := range volumes.Items {
-		ch <- prometheus.MustNewConstMetric(
-			c.ReductionDesc,
-			prometheus.GaugeValue,
-			v.Space.DataReduction,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.Shared,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "shared",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.Snapshots,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "snapshots",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.System,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "system",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.ThinProvisioning,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "thin_provisioning",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.TotalPhysical,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_physical",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.TotalProvisioned,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_provisioned",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.TotalReduction,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_reduction",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.Unique,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "unique",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.Virtual,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "virtual",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.Replication,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "replication",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.SharedEffective,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "shared_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.SnapshotsEffective,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "snapshots_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.UniqueEffective,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "unique_effective",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.SpaceDesc,
-			prometheus.GaugeValue,
-			v.Space.TotalEffective,
-			purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_effective",
-		)
-        }
+		if v.Space.DataReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.ReductionDesc,
+				prometheus.GaugeValue,
+				*v.Space.DataReduction,
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name,
+			)
+		}
+		if v.Space.Shared != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.Shared),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "shared",
+			)
+		}
+		if v.Space.Snapshots != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.Snapshots),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "snapshots",
+			)
+		}
+		if v.Space.System != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.System),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "system",
+			)
+		}
+		if v.Space.ThinProvisioning != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*v.Space.ThinProvisioning,
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "thin_provisioning",
+			)
+		}
+		if v.Space.TotalPhysical != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.TotalPhysical),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_physical",
+			)
+		}
+		if v.Space.TotalProvisioned != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.TotalProvisioned),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_provisioned",
+			)
+		}
+		if v.Space.TotalReduction != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				*v.Space.TotalReduction,
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_reduction",
+			)
+		}
+		if v.Space.Unique != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.Unique),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "unique",
+			)
+		}
+		if v.Space.Virtual != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.Virtual),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "virtual",
+			)
+		}
+		if v.Space.Replication != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.Replication),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "replication",
+			)
+		}
+		if v.Space.SharedEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.SharedEffective),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "shared_effective",
+			)
+		}
+		if v.Space.SnapshotsEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.SnapshotsEffective),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "snapshots_effective",
+			)
+		}
+		if v.Space.UniqueEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.UniqueEffective),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "unique_effective",
+			)
+		}
+		if v.Space.TotalEffective != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.SpaceDesc,
+				prometheus.GaugeValue,
+				float64(*v.Space.TotalEffective),
+				purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, "total_effective",
+			)
+		}
+	}
 }
 
 func NewVolumesSpaceCollector(volumes *client.VolumesList) *VolumesSpaceCollector {

--- a/internal/openmetrics-exporter/volumes_space_collector_test.go
+++ b/internal/openmetrics-exporter/volumes_space_collector_test.go
@@ -1,17 +1,15 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
-
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
+	"regexp"
+	"strings"
+	"testing"
 )
 
 func TestVolumesSpaceCollector(t *testing.T) {
@@ -23,35 +21,65 @@ func TestVolumesSpaceCollector(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/volumes$`)
 		if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
 		} else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
 		}
-	    }))
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	want := make(map[string]bool)
 	for _, v := range volumes.Items {
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.DataReduction)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.Shared)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.Snapshots)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"system\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.System)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.ThinProvisioning)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.TotalPhysical)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.TotalProvisioned)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.TotalReduction)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.Unique)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.Virtual)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.Replication)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.SharedEffective)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.SnapshotsEffective)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.UniqueEffective)] = true
-		want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa + v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, v.Space.TotalEffective)] = true
+		if v.Space.DataReduction != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, *v.Space.DataReduction)] = true
+		}
+		if v.Space.Shared != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"shared\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.Shared))] = true
+		}
+		if v.Space.Snapshots != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"snapshots\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.Snapshots))] = true
+		}
+		if v.Space.ThinProvisioning != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"system\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.ThinProvisioning))] = true
+		}
+		if v.Space.ThinProvisioning != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"thin_provisioning\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, *v.Space.ThinProvisioning)] = true
+		}
+		if v.Space.TotalPhysical != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_physical\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.TotalPhysical))] = true
+		}
+		if v.Space.TotalProvisioned != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_provisioned\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.TotalProvisioned))] = true
+		}
+		if v.Space.TotalReduction != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_reduction\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, *v.Space.TotalReduction)] = true
+		}
+		if v.Space.Unique != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"unique\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.Unique))] = true
+		}
+		if v.Space.Virtual != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"virtual\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.Virtual))] = true
+		}
+		if v.Space.Replication != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"replication\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.Replication))] = true
+		}
+		if v.Space.SharedEffective != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"shared_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.SharedEffective))] = true
+		}
+		if v.Space.SnapshotsEffective != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"snapshots_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.SnapshotsEffective))] = true
+		}
+		if v.Space.UniqueEffective != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"unique_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.UniqueEffective))] = true
+		}
+		if v.Space.TotalEffective != nil {
+			want[fmt.Sprintf("label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"pod\" value:\"%s\"} label:{name:\"space\" value:\"total_effective\"} label:{name:\"volume_group\" value:\"%s\"} gauge:{value:%g}", purenaa+v.Serial, v.Name, v.Pod.Name, v.VolumeGroup.Name, float64(*v.Space.TotalEffective))] = true
+		}
 	}
 	defer server.Close()
 	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)

--- a/internal/rest-client/space.go
+++ b/internal/rest-client/space.go
@@ -1,19 +1,21 @@
 package client
 
 type Space struct {
-	DataReduction        float64 `json:"data_reduction"`
-	Shared               float64 `json:"shared"`
-	Snapshots            float64 `json:"snapshots"`
-	System               float64 `json:"system"`
-	ThinProvisioning     float64 `json:"thin_provisioning"`
-	TotalPhysical        float64 `json:"total_physical"`
-	TotalProvisioned     float64 `json:"total_provisioned"`
-	TotalReduction       float64 `json:"total_reduction"`
-	Unique               float64 `json:"unique"`
-	Virtual              float64 `json:"virtual"`
-	Replication          float64 `json:"replication"`
-        SharedEffective      float64 `json:"shared_effective"`
-        SnapshotsEffective   float64 `json:"snapshots_effective"`
-        UniqueEffective      float64 `json:"unique_effective"`
-        TotalEffective       float64 `json:"total_effective"`
+	DataReduction      *float64 `json:"data_reduction"`
+	Shared             *int64   `json:"shared"`
+	Snapshots          *int64   `json:"snapshots"`
+	System             *int64   `json:"system"`
+	ThinProvisioning   *float64 `json:"thin_provisioning"`
+	TotalPhysical      *int64   `json:"total_physical"`
+	TotalProvisioned   *int64   `json:"total_provisioned"`
+	TotalReduction     *float64 `json:"total_reduction"`
+	Unique             *int64   `json:"unique"`
+	Virtual            *int64   `json:"virtual"`
+	UsedProvisioned    *int64   `json:"used_provisioned"`
+	TotalUsed          *int64   `json:"total_used"`
+	SharedEffective    *int64   `json:"shared_effective"`
+	SnapshotsEffective *int64   `json:"snapshots_effective"`
+	UniqueEffective    *int64   `json:"unique_effective"`
+	TotalEffective     *int64   `json:"total_effective"`
+	Replication        *int64   `json:"replication"`
 }


### PR DESCRIPTION
We currently have a lot of `null` Space objects that are reporting as 0 because of how go unmarshals json if it's an `int` or `float` Type

Per [OpenMetrics.md](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md)
````
Metric values in OpenMetrics MUST be either floating points or integers.
````
Thus metric values with the value of `null` should NOT be presented. 

Before:
````
purefa_directory_space_bytes{name="FA05Test:root",space="replication"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="shared"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="shared_effective"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="snapshots"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="snapshots_effective"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="system"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="thin_provisioning"} 1
purefa_directory_space_bytes{name="FA05Test:root",space="total_effective"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="total_physical"} 172
purefa_directory_space_bytes{name="FA05Test:root",space="total_provisioned"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="total_reduction"} 1
purefa_directory_space_bytes{name="FA05Test:root",space="unique"} 172
purefa_directory_space_bytes{name="FA05Test:root",space="unique_effective"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="virtual"} 0
````

After:
````
purefa_directory_space_bytes{name="FA05Test:root",space="snapshots"} 0
purefa_directory_space_bytes{name="FA05Test:root",space="thin_provisioning"} 1
purefa_directory_space_bytes{name="FA05Test:root",space="total_physical"} 172
purefa_directory_space_bytes{name="FA05Test:root",space="total_reduction"} 1
purefa_directory_space_bytes{name="FA05Test:root",space="unique"} 172
purefa_directory_space_bytes{name="FA05Test:root",space="virtual"} 0
````

Before:
````
purefa_array_space_bytes{space="capacity"} 6.2758213124096e+13
purefa_array_space_bytes{space="empty"} 3.4472971574918e+13
purefa_array_space_bytes{space="replication"} 0
purefa_array_space_bytes{space="shared"} 1.5353494870462e+13
purefa_array_space_bytes{space="shared_effective"} 0
purefa_array_space_bytes{space="snapshots"} 2.427924510022e+12
purefa_array_space_bytes{space="snapshots_effective"} 0
purefa_array_space_bytes{space="system"} 0
purefa_array_space_bytes{space="thin_provisioning"} 0.7324006219274994
purefa_array_space_bytes{space="total_effective"} 0
purefa_array_space_bytes{space="total_physical"} 2.8285241549178e+13
purefa_array_space_bytes{space="total_provisioned"} 0
purefa_array_space_bytes{space="total_reduction"} 17.726795829106823
purefa_array_space_bytes{space="unique"} 1.0503822168694e+13
purefa_array_space_bytes{space="unique_effective"} 0
purefa_array_space_bytes{space="virtual"} 9.1918033703527e+13
````

After:
````
purefa_array_space_bytes{space="capacity"} 6.2758213124096e+13
purefa_array_space_bytes{space="empty"} 3.4472971574918e+13
purefa_array_space_bytes{space="replication"} 0
purefa_array_space_bytes{space="shared"} 1.5353494870462e+13
purefa_array_space_bytes{space="snapshots"} 2.427924510022e+12
purefa_array_space_bytes{space="system"} 0
purefa_array_space_bytes{space="thin_provisioning"} 0.7324006219274994
purefa_array_space_bytes{space="total_physical"} 2.8285241549178e+13
purefa_array_space_bytes{space="total_reduction"} 17.726795829106823
purefa_array_space_bytes{space="unique"} 1.0503822168694e+13
purefa_array_space_bytes{space="virtual"} 9.1918033703527e+13
````