### PR TITLE
Support passing the HTTP Header X-Request-ID into Purity API requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GOTEST=$(GOCMD) test
 GOVET=$(GOCMD) vet
 BINARY_NAME=pure-fa-om-exporter
 MODULE_NAME=purestorage/fa-openmetrics-exporter
+UserAgentBase=Pure_FA_OpenMetrics_exporter
 VERSION?=1.0.18
 SERVICE_PORT?=9490
 DOCKER_REGISTRY?= quay.io/purestorage/
@@ -26,11 +27,11 @@ init:
 
 build: ## Build project and put the output binary in out/bin/
 	mkdir -p out/bin
-	CGO_ENABLED=0 GO111MODULE=on $(GOCMD) build -a -mod=readonly -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$(VERSION)'" -o out/bin/$(BINARY_NAME) cmd/fa-om-exporter/main.go
+	CGO_ENABLED=0 GO111MODULE=on $(GOCMD) build -a -mod=readonly -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.FARestUserAgentBase=$(UserAgentBase)'" -o out/bin/$(BINARY_NAME) cmd/fa-om-exporter/main.go
 
 build-with-vendor: ## Build project using the vendor directory and put the output binary in out/bin/
 	mkdir -p out/bin
-	CGO_ENABLED=0 GO111MODULE=on $(GOCMD) build -a -mod=vendor -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$(VERSION)'" -o out/bin/$(BINARY_NAME) cmd/fa-om-exporter/main.go
+	CGO_ENABLED=0 GO111MODULE=on $(GOCMD) build -a -mod=vendor -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$(VERSION)' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.FARestUserAgentBase=$(UserAgentBase)'" -o out/bin/$(BINARY_NAME) cmd/fa-om-exporter/main.go
 
 clean: ## Remove build related file
 	rm -fr ./bin

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ make docker-build
 ```
 
 
-
 ### Authentication
 
 Authentication is used by the exporter as the mechanism to cross authenticate to the scraped appliance, therefore for each array it is required to provide the REST API token for an account that has a 'readonly' role. The api-token can be provided in two ways

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ make docker-build
 ```
 
 
+
 ### Authentication
 
 Authentication is used by the exporter as the mechanism to cross authenticate to the scraped appliance, therefore for each array it is required to provide the REST API token for an account that has a 'readonly' role. The api-token can be provided in two ways
@@ -90,6 +91,12 @@ The second option provides the FlashArray/api-token key-pair map for a list of a
 ### TLS Support
 
 The exporter can be started in TLS mode (HTTPS, mutually exclusive with the HTTP mode) by providing the X.509 certificate and key files in the command parameters. Self-signed certificates are also accepted.
+
+### Supported Headers
+
+#### X-Request-ID (Optional)
+
+The `X-Request-ID` Header, as used in the Purity API, may be used when calling the OpenMetrics exporter by using the HTTP Header `X-Request-ID`. It will then be passed and used when requesting metrics from the Purity API.
 
 ### Usage
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=1.0.18
+ARG UserAgentBase=Pure_FA_OpenMetrics_exporter
 
 WORKDIR /usr/src/app
 
@@ -9,7 +10,7 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-RUN CGO_ENABLED=1 go build -mod=readonly -a -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$VERSION' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$VERSION'" -v -o /usr/local/bin/pure-fa-om-exporter cmd/fa-om-exporter/main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -a -tags 'netgo osusergo static_build' -ldflags="-X 'main.version=v$VERSION' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.FARestUserAgentBase=$UserAgentBase' -X 'purestorage/fa-openmetrics-exporter/internal/rest-client.UserAgentVersion=$VERSION'" -v -o /usr/local/bin/pure-fa-om-exporter cmd/fa-om-exporter/main.go
 
 
 # alpine is used here as it seems to be the minimal image that passes quay.io vulnerability scan

--- a/cmd/fa-om-exporter/main.go
+++ b/cmd/fa-om-exporter/main.go
@@ -28,11 +28,11 @@ func fileExists(args []string) error {
 }
 
 func isFile(filename string) bool {
-   info, err := os.Stat(filename)
-   if os.IsNotExist(err) {
-      return false
-   }
-   return !info.IsDir()
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }
 
 func main() {
@@ -72,14 +72,14 @@ func main() {
 	}
 	if (len(*cert) > 0 && len(*key) == 0) || (len(*cert) == 0 && len(*key) > 0) {
 		log.Fatal("Both certificate and key must be specified to enable TLS")
-        }
-	if (len(*cert) > 0 && len(*key) > 0) {
+	}
+	if len(*cert) > 0 && len(*key) > 0 {
 		if !isFile(*cert) {
 			log.Fatal("TLS cert file not found")
-        	} else if !isFile (*key) {
+		} else if !isFile(*key) {
 			log.Fatal("TLS key file not found")
 		}
-        }
+	}
 	debug = *d
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("Start Pure FlashArray exporter %s on %s", version, addr)
@@ -143,16 +143,18 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	address, apitoken := arraytokens.GetArrayParams(endpoint)
 	if len(authFields) == 2 && strings.ToLower(authFields[0]) == "bearer" {
 		apitoken = authFields[1]
-                address = endpoint
+		address = endpoint
 	}
 	if apitoken == "" {
 		http.Error(w, "Target authorization token is missing", http.StatusBadRequest)
 		return
 	}
 
-        uagent := r.Header.Get("User-Agent")
+	uagent := r.Header.Get("User-Agent")
+	rid := r.Header.Get("X-Request-ID")
+
 	registry := prometheus.NewRegistry()
-	faclient := client.NewRestClient(address, apitoken, apiver, uagent, debug)
+	faclient := client.NewRestClient(address, apitoken, apiver, uagent, rid, debug)
 	if faclient.Error != nil {
 		http.Error(w, "Error connecting to FlashArray. Check your management endpoint and/or api token are correct.", http.StatusBadRequest)
 		return

--- a/internal/openmetrics-exporter/alerts_collector_test.go
+++ b/internal/openmetrics-exporter/alerts_collector_test.go
@@ -52,7 +52,8 @@ func TestAlertsCollector(t *testing.T) {
 
 		want[fmt.Sprintf("label:{name:\"category\" value:\"%s\"} label:{name:\"code\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"created\" value:\"%s\"} label:{name:\"issue\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"severity\" value:\"%s\"} label:{name:\"summary\" value:\"%s\"} gauge:{value:%g}", alert[0], alert[1], alert[2], alert[3], alert[4], alert[5], alert[6], alert[7], n)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	ac := NewAlertsCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/alerts_collector_test.go
+++ b/internal/openmetrics-exporter/alerts_collector_test.go
@@ -53,7 +53,6 @@ func TestAlertsCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"category\" value:\"%s\"} label:{name:\"code\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"created\" value:\"%s\"} label:{name:\"issue\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"severity\" value:\"%s\"} label:{name:\"summary\" value:\"%s\"} gauge:{value:%g}", alert[0], alert[1], alert[2], alert[3], alert[4], alert[5], alert[6], alert[7], n)] = true
 	}
 	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 	ac := NewAlertsCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_collector_test.go
@@ -50,7 +50,6 @@ func TestArraysCollector(t *testing.T) {
 	want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"subscription_type\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, s.Service, a.Id, a.Version)] = true
 
 	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 	ac := NewArraysCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_collector_test.go
@@ -49,7 +49,8 @@ func TestArraysCollector(t *testing.T) {
 
 	want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"subscription_type\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, s.Service, a.Id, a.Version)] = true
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	ac := NewArraysCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_controllers_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_controllers_collector_test.go
@@ -39,7 +39,8 @@ func TestArrayControllersCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"mode\" value:\"%s\"} label:{name:\"model\"value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} label:{name:\"type\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:\"%g\"}", ctl.Mode, ctl.Model, ctl.Name, ctl.Status, ctl.Type, ctl.Version, (float64(ctl.ModeSince)/1000))] = true
 	}
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	dc := NewControllersCollector(c)
 	metricsCheck(t, dc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_performance_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_performance_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestArrayPerformanceCollector(t *testing.T) {
@@ -23,16 +22,16 @@ func TestArrayPerformanceCollector(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance$`)
 		if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
 		} else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
 		}
-	   }))
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -65,7 +64,8 @@ func TestArrayPerformanceCollector(t *testing.T) {
 	want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} gauge:{value:%g}", p.BytesPerRead)] = true
 	want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} gauge:{value:%g}", p.BytesPerWrite)] = true
 	want[fmt.Sprintf("gauge:{value:%g}", p.QueueDepth)] = true
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewArraysPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/arrays_space_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_space_collector_test.go
@@ -86,7 +86,8 @@ func TestArraySpaceCollector(t *testing.T) {
 	want[fmt.Sprintf("label:{name:\"space\" value:\"empty\"} gauge:{value:%g}", a.Capacity-(float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique)))] = true
 	want[fmt.Sprintf("gauge:{value:%g}", (float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique))/a.Capacity*100)] = true
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	ac := NewArraySpaceCollector(c)
 	metricsCheck(t, ac, want)
 }

--- a/internal/openmetrics-exporter/dirs_performance_collector_test.go
+++ b/internal/openmetrics-exporter/dirs_performance_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestDirectoriesPerformanceCollector(t *testing.T) {
@@ -23,16 +22,16 @@ func TestDirectoriesPerformanceCollector(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/directories/performance$`)
 		if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
 		} else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
 		}
-           }))
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -50,7 +49,8 @@ func TestDirectoriesPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewDirectoriesPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/dirs_space_collector_test.go
+++ b/internal/openmetrics-exporter/dirs_space_collector_test.go
@@ -83,7 +83,8 @@ func TestDirectoriesSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	hc := NewDirectoriesSpaceCollector(c)
 	metricsCheck(t, hc, want)
 }

--- a/internal/openmetrics-exporter/drives_collector_test.go
+++ b/internal/openmetrics-exporter/drives_collector_test.go
@@ -39,7 +39,8 @@ func TestDriveCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"component_name\" value:\"%s\"} label:{name:\"component_status\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} gauge:{value:\"%g\"}", d.Name, d.Type, d.Status, d.Protocol, d.Capacity)] = true
 	}
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	dc := NewDriveCollector(c)
 	metricsCheck(t, dc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/host_connections_collector_test.go
+++ b/internal/openmetrics-exporter/host_connections_collector_test.go
@@ -38,7 +38,8 @@ func TestHostConnectionsCollector(t *testing.T) {
 	for _, hc := range conn.Items {
 		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"hostgroup\" value:\"%s\"} label:{name:\"volume\" value:\"%s\"} gauge:{value:1}", hc.Host.Name, hc.HostGroup.Name, hc.Volume.Name)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	hc := NewHostConnectionsCollector(c)
 	metricsCheck(t, hc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/hosts_performance_collector_test.go
+++ b/internal/openmetrics-exporter/hosts_performance_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestHostsPerformanceCollector(t *testing.T) {
@@ -20,18 +19,18 @@ func TestHostsPerformanceCollector(t *testing.T) {
 	var hosts client.HostsPerformanceList
 	json.Unmarshal(res, &hosts)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hosts/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hosts/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -61,7 +60,8 @@ func TestHostsPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewHostsPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/hosts_space_collector_test.go
+++ b/internal/openmetrics-exporter/hosts_space_collector_test.go
@@ -84,7 +84,8 @@ func TestHostsSpaceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"details\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:1}", h.Name, h.PortConnectivity.Details, h.PortConnectivity.Status)] = true
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	hc := NewHostsSpaceCollector(c)
 	metricsCheck(t, hc, want)
 }

--- a/internal/openmetrics-exporter/network_interface_collector_test.go
+++ b/internal/openmetrics-exporter/network_interface_collector_test.go
@@ -39,7 +39,8 @@ func TestNetworkInterfacesCollectorTest(t *testing.T) {
 	for _, h := range hwl.Items {
 		want[fmt.Sprintf("label:{name:\"enabled\"  value:\"%s\"}  label:{name:\"ethsubtype\"  value:\"%s\"}  label:{name:\"name\"  value:\"%s\"}  label:{name:\"services\"  value:\"%s\"}  label:{name:\"type\"  value:\"%s\"}  gauge:{value:%g}", strconv.FormatBool(h.Enabled), h.Eth.Subtype, h.Name, strings.Join(h.Services, ", "), h.InterfaceType, float64(h.Speed))] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	nc := NewNetworkInterfacesCollector(c)
 	metricsCheck(t, nc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/network_interfaces_performance_collector_test.go
+++ b/internal/openmetrics-exporter/network_interfaces_performance_collector_test.go
@@ -1,37 +1,36 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestNetworkInterfacesPerformanceCollector(t *testing.T) {
 	res, _ := os.ReadFile("../../test/data/network_interfaces_performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-	var  nics client.NetworkInterfacesPerformanceList
+	var nics client.NetworkInterfacesPerformanceList
 	json.Unmarshal(res, &nics)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/network-interfaces/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/network-interfaces/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -62,7 +61,8 @@ func TestNetworkInterfacesPerformanceCollector(t *testing.T) {
 			want[fmt.Sprintf("label:{name:\"dimension\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"type\" value:\"%s\"} gauge:{value:%g}", "transmitted_invalid_words_per_sec", n.Name, n.InterfaceType, n.Fc.TransmittedInvalidWordsPerSec)] = true
 		}
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewNetworkInterfacesPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/pod_replica_links_lag_collector_test.go
+++ b/internal/openmetrics-exporter/pod_replica_links_lag_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestPodReplicaLinksLagCollector(t *testing.T) {
@@ -20,28 +19,29 @@ func TestPodReplicaLinksLagCollector(t *testing.T) {
 	var prlpl client.PodReplicaLinksLagList
 	json.Unmarshal(res, &prlpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pod-replica-links/lag$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pod-replica-links/lag$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
 	want := make(map[string]bool)
 	for _, p := range prlpl.Items {
-                want[fmt.Sprintf("label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.Status, p.Lag.Avg)] = true
-                want[fmt.Sprintf("label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.Status, p.Lag.Max)] = true
+		want[fmt.Sprintf("label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.Status, p.Lag.Avg)] = true
+		want[fmt.Sprintf("label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.Status, p.Lag.Max)] = true
 
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewPodReplicaLinksLagCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/pod_replica_links_performance_collector_test.go
+++ b/internal/openmetrics-exporter/pod_replica_links_performance_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestPodReplicaLinksPerformanceCollector(t *testing.T) {
@@ -20,29 +19,30 @@ func TestPodReplicaLinksPerformanceCollector(t *testing.T) {
 	var prlpl client.PodReplicaLinksPerformanceList
 	json.Unmarshal(res, &prlpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pod-replica-links/performance/replication$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pod-replica-links/performance/replication$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
 	want := make(map[string]bool)
 	for _, p := range prlpl.Items {
-                want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_to_remote\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecToRemote)] = true
-                want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_from_remote\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecFromRemote)] = true
-                want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_total\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecTotal)] = true
+		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_to_remote\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecToRemote)] = true
+		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_from_remote\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecFromRemote)] = true
+		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_total\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecTotal)] = true
 
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewPodReplicaLinksPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/pods_performance_collector_test.go
+++ b/internal/openmetrics-exporter/pods_performance_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestPodsPerformanceCollector(t *testing.T) {
@@ -20,18 +19,18 @@ func TestPodsPerformanceCollector(t *testing.T) {
 	var pods client.PodsPerformanceList
 	json.Unmarshal(res, &pods)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pods/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pods/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -63,7 +62,8 @@ func TestPodsPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewPodsPerformanceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/pods_performance_replication_collector_test.go
+++ b/internal/openmetrics-exporter/pods_performance_replication_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-	"regexp"
-	"strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fa-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fa-openmetrics-exporter/internal/rest-client"
 )
 
 func TestPodsPerformanceReplicationCollector(t *testing.T) {
@@ -20,18 +19,18 @@ func TestPodsPerformanceReplicationCollector(t *testing.T) {
 	var pods client.PodsPerformanceReplicationList
 	json.Unmarshal(res, &pods)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pods/performance/replication$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
-                        w.Header().Set("x-auth-token", "faketoken")
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(res))
-                }
-           }))
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/pods/performance/replication$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
+			w.Header().Set("x-auth-token", "faketoken")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(res))
+		}
+	}))
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	defer server.Close()
@@ -50,7 +49,8 @@ func TestPodsPerformanceReplicationCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"sync\"} label:{name:\"direction\" value:\"total\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Pod.Name, p.SyncBytesPerSec.TotalBytesPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"periodic\"} label:{name:\"direction\" value:\"total\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Pod.Name, p.PeriodicBytesPerSec.TotalBytesPerSec)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewPodsPerformanceReplicationCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/pods_space_collector_test.go
+++ b/internal/openmetrics-exporter/pods_space_collector_test.go
@@ -92,7 +92,8 @@ func TestPodsSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 	pc := NewPodsSpaceCollector(c)
 	metricsCheck(t, pc, want)
 }

--- a/internal/openmetrics-exporter/ports_collector_test.go
+++ b/internal/openmetrics-exporter/ports_collector_test.go
@@ -38,7 +38,7 @@ func TestPortsCollector(t *testing.T) {
 	for _, h := range hwl.Items {
 		want[fmt.Sprintf("label:{name:\"iqn\"  value:\"%s\"}  label:{name:\"name\"  value:\"%s\"}  label:{name:\"nqn\"  value:\"%s\"}  label:{name:\"portal\"  value:\"%s\"}  label:{name:\"wwn\"  value:\"%s\"}  gauge:{value:1}", h.Iqn, h.Name, h.Nqn, h.Portal, h.Wwn)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 	pc := NewPortsCollector(c)
 	metricsCheck(t, pc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/volumes_space_collector_test.go
+++ b/internal/openmetrics-exporter/volumes_space_collector_test.go
@@ -82,7 +82,7 @@ func TestVolumesSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 	vl := c.GetVolumes()
 	pc := NewVolumesSpaceCollector(vl)
 	metricsCheck(t, pc, want)

--- a/internal/rest-client/alerts_test.go
+++ b/internal/rest-client/alerts_test.go
@@ -43,7 +43,7 @@ func TestAlerts(t *testing.T) {
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	t.Run("alerts_open", func(t *testing.T) {
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		al := c.GetAlerts("state='open'")
 		if diff := cmp.Diff(al.Items, aopen.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -51,7 +51,7 @@ func TestAlerts(t *testing.T) {
 		}
 	})
 	t.Run("alerts_all", func(t *testing.T) {
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		al := c.GetAlerts("")
 		if diff := cmp.Diff(al.Items, aall.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_performance_test.go
+++ b/internal/rest-client/arrays_performance_test.go
@@ -35,7 +35,7 @@ func TestArraysPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("arrays_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		apl := c.GetArraysPerformance()
 		if diff := cmp.Diff(apl.Items[0], arrsp.Items[0]); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_test.go
+++ b/internal/rest-client/arrays_test.go
@@ -35,7 +35,7 @@ func TestArrays(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("arrays_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		al := c.GetArrays()
 		if diff := cmp.Diff(al.Items[0], arrs.Items[0]); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/connections_test.go
+++ b/internal/rest-client/connections_test.go
@@ -35,7 +35,7 @@ func TestConnections(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("connections_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		cl := c.GetConnections()
 		if diff := cmp.Diff(cl.Items, conns.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/controllers_test.go
+++ b/internal/rest-client/controllers_test.go
@@ -35,7 +35,7 @@ func TestControllers(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("controllers_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		cl := c.GetControllers()
 		if diff := cmp.Diff(cl.Items, cont.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/directories_performance_test.go
+++ b/internal/rest-client/directories_performance_test.go
@@ -35,7 +35,7 @@ func TestDirectoriesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("directories_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		dpl := c.GetDirectoriesPerformance()
 		if diff := cmp.Diff(dpl.Items, dirsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/directories_test.go
+++ b/internal/rest-client/directories_test.go
@@ -35,7 +35,7 @@ func TestDirectories(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("directories_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		dl := c.GetDirectories()
 		if diff := cmp.Diff(dl.Items, dirs.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/drives_test.go
+++ b/internal/rest-client/drives_test.go
@@ -35,7 +35,7 @@ func TestDrive(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("drive_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		dl := c.GetDrives()
 		if diff := cmp.Diff(dl.Items, dr.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/flasharray_client.go
+++ b/internal/rest-client/flasharray_client.go
@@ -35,16 +35,18 @@ type FAClient struct {
 	RestClient *resty.Client
 	ApiVersion string
 	XAuthToken string
+	XRequestID string
 	Error      error
 }
 
-func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, debug bool) *FAClient {
+func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, rid string, debug bool) *FAClient {
 	type ApiVersions struct {
 		Versions []string `json:"version"`
 	}
 	fa := &FAClient{
 		EndPoint:   endpoint,
 		ApiToken:   apitoken,
+		XRequestID: "",
 		RestClient: resty.New(),
 		XAuthToken: "",
 	}
@@ -53,6 +55,7 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, uagent s
 	fa.RestClient.SetHeaders(map[string]string{
 		"Content-Type": "application/json",
 		"Accept":       "application/json",
+		"X-Request-ID": rid,
 	})
 	if debug {
 		fa.RestClient.SetDebug(true)
@@ -96,8 +99,10 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, uagent s
 		return fa
 	}
 	fa.XAuthToken = res.Header().Get("x-auth-token")
+	fa.XRequestID = res.Header().Get("X-Request-ID")
 	fa.RestClient.SetHeader("x-auth-token", fa.XAuthToken)
 	fa.RestClient.SetHeader("User-Agent", FARestUserAgent+" ("+uagent+")")
+	fa.RestClient.SetHeader("X-Request-ID", fa.XRequestID)
 	return fa
 }
 
@@ -123,6 +128,8 @@ func (fa *FAClient) RefreshSession() *FAClient {
 		return fa
 	}
 	fa.XAuthToken = res.Header().Get("x-auth-token")
+	fa.XRequestID = res.Header().Get("X-Request-ID")
 	fa.RestClient.SetHeader("x-auth-token", fa.XAuthToken)
+	fa.RestClient.SetHeader("X-Request-ID", fa.XRequestID)
 	return fa
 }

--- a/internal/rest-client/flasharray_client_test.go
+++ b/internal/rest-client/flasharray_client_test.go
@@ -29,7 +29,7 @@ func TestNewRestClient(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("login", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		if c.EndPoint != e || c.ApiToken != "fake-api-token" || c.XAuthToken != "faketoken" {
 			t.Errorf("expected (%s, fake-api-token, faketoken), got (%s %s %s)", e, c.EndPoint, c.ApiToken, c.XAuthToken)
 		}

--- a/internal/rest-client/hardware_test.go
+++ b/internal/rest-client/hardware_test.go
@@ -35,7 +35,7 @@ func TestHardware(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hardware_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		hl := c.GetHardware()
 		if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_balance_test.go
+++ b/internal/rest-client/hosts_balance_test.go
@@ -35,7 +35,7 @@ func TestHostsBalance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_balance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		hbl := c.GetHostsBalance()
 		if diff := cmp.Diff(hbl.Items, hostsb.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_performance_test.go
+++ b/internal/rest-client/hosts_performance_test.go
@@ -34,7 +34,7 @@ func TestHostsPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		hpl := c.GetHostsPerformance()
 		if diff := cmp.Diff(hpl.Items, hostsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_test.go
+++ b/internal/rest-client/hosts_test.go
@@ -35,7 +35,7 @@ func TestHosts(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		hl := c.GetHosts()
 		if diff := cmp.Diff(hl.Items, hosts.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/network_interface_test.go
+++ b/internal/rest-client/network_interface_test.go
@@ -35,7 +35,7 @@ func TestNetworkInterfaces(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("network_interfaces_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		nl := c.GetNetworkInterfaces()
 		if diff := cmp.Diff(nl.Items, nw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/network_performance_test.go
+++ b/internal/rest-client/network_performance_test.go
@@ -35,7 +35,7 @@ func TestNetworkInterfacesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("network_interfaces_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		nl := c.GetNetworkInterfacesPerformance()
 		if diff := cmp.Diff(nl.Items, nw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pod_replica_links_lag_test.go
+++ b/internal/rest-client/pod_replica_links_lag_test.go
@@ -35,7 +35,7 @@ func TestPodReplicaLinksLag(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pod_replica_links_lag_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		prll := c.GetPodReplicaLinksLag()
 		if diff := cmp.Diff(prll.Items, podrll.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pod_replica_links_performance_test.go
+++ b/internal/rest-client/pod_replica_links_performance_test.go
@@ -35,7 +35,7 @@ func TestPodReplicaLinksPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pod_replica_links_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		prlpl := c.GetPodReplicaLinksPerformance()
 		if diff := cmp.Diff(prlpl.Items, podrlp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_performance_replication_test.go
+++ b/internal/rest-client/pods_performance_replication_test.go
@@ -35,7 +35,7 @@ func TestPodsPerformanceReplication(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_performance_replcation_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		ppl := c.GetPodsPerformanceReplication()
 		if diff := cmp.Diff(ppl.Items, podsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_performance_test.go
+++ b/internal/rest-client/pods_performance_test.go
@@ -35,7 +35,7 @@ func TestPodsPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		ppl := c.GetPodsPerformance()
 		if diff := cmp.Diff(ppl.Items, podsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_test.go
+++ b/internal/rest-client/pods_test.go
@@ -35,7 +35,8 @@ func TestPods(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 		pl := c.GetPods()
 		if diff := cmp.Diff(pl.Items, pods.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_test.go
+++ b/internal/rest-client/pods_test.go
@@ -36,7 +36,6 @@ func TestPods(t *testing.T) {
 	t.Run("pods_1", func(t *testing.T) {
 		defer server.Close()
 		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 		pl := c.GetPods()
 		if diff := cmp.Diff(pl.Items, pods.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/ports_test.go
+++ b/internal/rest-client/ports_test.go
@@ -35,7 +35,7 @@ func TestPorts(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("ports_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
 		pl := c.GetPorts()
 		if diff := cmp.Diff(pl.Items, ports.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/subscriptions_test.go
+++ b/internal/rest-client/subscriptions_test.go
@@ -35,7 +35,8 @@ func TestSubscriptions(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("subscriptions_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 		vpl := c.GetSubscriptions()
 		if diff := cmp.Diff(vpl.Items, subs.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/subscriptions_test.go
+++ b/internal/rest-client/subscriptions_test.go
@@ -36,7 +36,6 @@ func TestSubscriptions(t *testing.T) {
 	t.Run("subscriptions_1", func(t *testing.T) {
 		defer server.Close()
 		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 		vpl := c.GetSubscriptions()
 		if diff := cmp.Diff(vpl.Items, subs.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_performance_test.go
+++ b/internal/rest-client/volumes_performance_test.go
@@ -36,7 +36,6 @@ func TestVolumesPerformance(t *testing.T) {
 	t.Run("volumes_performance_1", func(t *testing.T) {
 		defer server.Close()
 		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 		vpl := c.GetVolumesPerformance()
 		if diff := cmp.Diff(vpl.Items, volsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_performance_test.go
+++ b/internal/rest-client/volumes_performance_test.go
@@ -35,7 +35,8 @@ func TestVolumesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("volumes_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 		vpl := c.GetVolumesPerformance()
 		if diff := cmp.Diff(vpl.Items, volsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_test.go
+++ b/internal/rest-client/volumes_test.go
@@ -35,7 +35,8 @@ func TestVolumes(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("volumes_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+
 		vl := c.GetVolumes()
 		if diff := cmp.Diff(vl.Items, vols.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_test.go
+++ b/internal/rest-client/volumes_test.go
@@ -36,7 +36,6 @@ func TestVolumes(t *testing.T) {
 	t.Run("volumes_1", func(t *testing.T) {
 		defer server.Close()
 		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
-
 		vl := c.GetVolumes()
 		if diff := cmp.Diff(vl.Items, vols.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
The Purity API supports the header `X-Request-ID` it was requested by a customer to allow them to pass this header along with the requests made by the OpenMetrics Exporter.