### PR TITLE
examples/config/k8s /operator: Fix broken links in README.md

### DIFF
--- a/examples/config/k8s/operator/README.md
+++ b/examples/config/k8s/operator/README.md
@@ -1,4 +1,4 @@
 # Deploying with the Prometheus Operator
 
 Install Prometheus using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), then deploy 
-the Pure FlashArray Prometheus exporter using the deployment file [pure-fa-exporter-deployment.yaml](./pure-fa-exporter-deployment.yaml). Configure Prometheus using the Probe custom resouce defined in the [pure-fa-probe.yaml](./pure-fa-probe.yaml).
+the Pure FlashArray Prometheus exporter using the deployment file [pure-fa-ome-deploy_tokens.yaml](./pure-fa-ome-deploy_tokens.yaml). Configure Prometheus using the Probe custom resouce defined in the [pure-fa-probe_tokens.yaml](./pure-fa-probe_tokens.yaml).


### PR DESCRIPTION
There are some filename changes in 0253a0e, causing links in `examples/config/k8s /operator/README.md` broken. This patch updates the filenames/paths to fix the error. 