### PR TITLE
Fix image path in pure-fa-ome-deploy_tokens.yaml

### DIFF
--- a/examples/config/k8s/operator/pure-fa-ome-deploy_tokens.yaml
+++ b/examples/config/k8s/operator/pure-fa-ome-deploy_tokens.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: pure-fa-om-exporter
-        image: quay.io/purestorage/pure-fa-om-exporter/pure-fa-om-exporter:latest
+        image: quay.io/purestorage/pure-fa-om-exporter:latest
         command: ["/pure-fa-om-exporter"]
         imagePullPolicy: "Always"
         args:


### PR DESCRIPTION
Correct the image path provided in the k8s deployment example. 