### PR TITLE
Update docker-compose.yaml to remove version

### DIFF
--- a/examples/config/docker/docker-compose.yaml
+++ b/examples/config/docker/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   pure-fa-om-exporter:
     image: quay.io/purestorage/pure-fa-om-exporter:latest


### PR DESCRIPTION
version is now obsolete and should be removed per spec

https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md

closes #144 