### PR TITLE
Add new URL parameter to API

### DIFF
--- a/cmd/fa-om-exporter/main.go
+++ b/cmd/fa-om-exporter/main.go
@@ -128,7 +128,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 			metrics = "all"
 		}
 	}
-	
+
 	endpoint := params.Get("endpoint")
 	address := params.Get("address")
 	apitoken := ""


### PR DESCRIPTION
This PR aims to reduce confusion by adding a new URL parameter named `address`.

The idea here is to allow the exporter to clearly understand the intent of the client when it comes to authorization of the `FAClient`. Currently, the API is somewhat confusing as seen from the conversation in issue #143, with confusion coming from how the exporter uses tokens from `tokens.yaml` vs tokens from the auth header of the incoming request .

By adding a new URL parameter, the intent of the client is clear:
- If the `endpoint` parameter is provided, the exporter should use the configured endpoint from `tokens.yaml` to authenticate.
- If the `address` parameter is provided, the exporter will expect the authentication to come from the auth header in the request.