### PR TITLE
Add secure mode to the exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ The `X-Request-ID` Header, as used in the Purity API, may be used when calling t
 
 ```shell
 
-usage: pure-fa-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-t|--tokens <file>] [-k|--key <file>] [-c|--cert <file>]
+usage: pure-fa-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-s|--secure] [-t|--tokens <file>] [-c|--cert "<value>"] [-k|--key "<value>"]
 
-                           Pure Storage FA OpenMetrics exporter
+Pure Storage FA OpenMetrics exporter
 
 Arguments:
 
@@ -111,9 +111,10 @@ Arguments:
   -a  --address  IP address for this exporter to bind to. Default: 0.0.0.0
   -p  --port     Port for this exporter to listen. Default: 9490
   -d  --debug    Enable debug. Default: false
+  -s  --secure   Enable TLS verification when connecting to array. Default: false
   -t  --tokens   API token(s) map file
-  -c  --cert     SSL/TLS certificate file. Required only for TLS
-  -k  --key      SSL/TLS private key file. Required only for TLS
+  -c  --cert     SSL/TLS certificate file. Required only for Exporter TLS
+  -k  --key      SSL/TLS private key file. Required only for Exporter TLS
 ```
 
 The array token configuration file must have to following syntax:

--- a/internal/openmetrics-exporter/alerts_collector_test.go
+++ b/internal/openmetrics-exporter/alerts_collector_test.go
@@ -52,7 +52,7 @@ func TestAlertsCollector(t *testing.T) {
 
 		want[fmt.Sprintf("label:{name:\"category\" value:\"%s\"} label:{name:\"code\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"created\" value:\"%s\"} label:{name:\"issue\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"severity\" value:\"%s\"} label:{name:\"summary\" value:\"%s\"} gauge:{value:%g}", alert[0], alert[1], alert[2], alert[3], alert[4], alert[5], alert[6], alert[7], n)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 	ac := NewAlertsCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_collector_test.go
@@ -49,7 +49,7 @@ func TestArraysCollector(t *testing.T) {
 
 	want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"subscription_type\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, s.Service, a.Id, a.Version)] = true
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 	ac := NewArraysCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_controllers_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_controllers_collector_test.go
@@ -39,7 +39,7 @@ func TestArrayControllersCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"mode\" value:\"%s\"} label:{name:\"model\"value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} label:{name:\"type\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:\"%g\"}", ctl.Mode, ctl.Model, ctl.Name, ctl.Status, ctl.Type, ctl.Version, (float64(ctl.ModeSince)/1000))] = true
 	}
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	dc := NewControllersCollector(c)
 	metricsCheck(t, dc, want)

--- a/internal/openmetrics-exporter/arrays_performance_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_performance_collector_test.go
@@ -64,7 +64,7 @@ func TestArrayPerformanceCollector(t *testing.T) {
 	want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} gauge:{value:%g}", p.BytesPerRead)] = true
 	want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} gauge:{value:%g}", p.BytesPerWrite)] = true
 	want[fmt.Sprintf("gauge:{value:%g}", p.QueueDepth)] = true
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewArraysPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/arrays_space_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_space_collector_test.go
@@ -86,7 +86,7 @@ func TestArraySpaceCollector(t *testing.T) {
 	want[fmt.Sprintf("label:{name:\"space\" value:\"empty\"} gauge:{value:%g}", a.Capacity-(float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique)))] = true
 	want[fmt.Sprintf("gauge:{value:%g}", (float64(*a.Space.System)+float64(*a.Space.Replication)+float64(*a.Space.Shared)+float64(*a.Space.Snapshots)+float64(*a.Space.Unique))/a.Capacity*100)] = true
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	ac := NewArraySpaceCollector(c)
 	metricsCheck(t, ac, want)

--- a/internal/openmetrics-exporter/dirs_performance_collector_test.go
+++ b/internal/openmetrics-exporter/dirs_performance_collector_test.go
@@ -49,7 +49,7 @@ func TestDirectoriesPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewDirectoriesPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/dirs_space_collector_test.go
+++ b/internal/openmetrics-exporter/dirs_space_collector_test.go
@@ -83,7 +83,7 @@ func TestDirectoriesSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	hc := NewDirectoriesSpaceCollector(c)
 	metricsCheck(t, hc, want)

--- a/internal/openmetrics-exporter/drives_collector_test.go
+++ b/internal/openmetrics-exporter/drives_collector_test.go
@@ -39,7 +39,7 @@ func TestDriveCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"component_name\" value:\"%s\"} label:{name:\"component_status\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} gauge:{value:\"%g\"}", d.Name, d.Type, d.Status, d.Protocol, d.Capacity)] = true
 	}
 
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	dc := NewDriveCollector(c)
 	metricsCheck(t, dc, want)

--- a/internal/openmetrics-exporter/hardware_collector_test.go
+++ b/internal/openmetrics-exporter/hardware_collector_test.go
@@ -44,7 +44,7 @@ func TestHardwareCollector(t *testing.T) {
 			want[fmt.Sprintf("label:{name:\"component_name\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} gauge:{value:%g}", h.Name, h.Type, float64(h.Voltage))] = true
 		}
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	hc := NewHardwareCollector(c)
 	metricsCheck(t, hc, want)

--- a/internal/openmetrics-exporter/host_connections_collector_test.go
+++ b/internal/openmetrics-exporter/host_connections_collector_test.go
@@ -38,7 +38,7 @@ func TestHostConnectionsCollector(t *testing.T) {
 	for _, hc := range conn.Items {
 		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"hostgroup\" value:\"%s\"} label:{name:\"volume\" value:\"%s\"} gauge:{value:1}", hc.Host.Name, hc.HostGroup.Name, hc.Volume.Name)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	hc := NewHostConnectionsCollector(c)
 	metricsCheck(t, hc, want)

--- a/internal/openmetrics-exporter/hosts_performance_collector_test.go
+++ b/internal/openmetrics-exporter/hosts_performance_collector_test.go
@@ -60,7 +60,7 @@ func TestHostsPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"host\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewHostsPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/hosts_space_collector_test.go
+++ b/internal/openmetrics-exporter/hosts_space_collector_test.go
@@ -84,7 +84,7 @@ func TestHostsSpaceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"host\" value:\"%s\"} label:{name:\"details\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:1}", h.Name, h.PortConnectivity.Details, h.PortConnectivity.Status)] = true
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	hc := NewHostsSpaceCollector(c)
 	metricsCheck(t, hc, want)

--- a/internal/openmetrics-exporter/network_interface_collector_test.go
+++ b/internal/openmetrics-exporter/network_interface_collector_test.go
@@ -39,7 +39,7 @@ func TestNetworkInterfacesCollectorTest(t *testing.T) {
 	for _, h := range hwl.Items {
 		want[fmt.Sprintf("label:{name:\"enabled\"  value:\"%s\"}  label:{name:\"ethsubtype\"  value:\"%s\"}  label:{name:\"name\"  value:\"%s\"}  label:{name:\"services\"  value:\"%s\"}  label:{name:\"type\"  value:\"%s\"}  gauge:{value:%g}", strconv.FormatBool(h.Enabled), h.Eth.Subtype, h.Name, strings.Join(h.Services, ", "), h.InterfaceType, float64(h.Speed))] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	nc := NewNetworkInterfacesCollector(c)
 	metricsCheck(t, nc, want)

--- a/internal/openmetrics-exporter/network_interfaces_performance_collector_test.go
+++ b/internal/openmetrics-exporter/network_interfaces_performance_collector_test.go
@@ -61,7 +61,7 @@ func TestNetworkInterfacesPerformanceCollector(t *testing.T) {
 			want[fmt.Sprintf("label:{name:\"dimension\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} label:{name:\"type\" value:\"%s\"} gauge:{value:%g}", "transmitted_invalid_words_per_sec", n.Name, n.InterfaceType, n.Fc.TransmittedInvalidWordsPerSec)] = true
 		}
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewNetworkInterfacesPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/pod_replica_links_lag_collector_test.go
+++ b/internal/openmetrics-exporter/pod_replica_links_lag_collector_test.go
@@ -40,7 +40,7 @@ func TestPodReplicaLinksLagCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} label:{name:\"status\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.Status, p.Lag.Max)] = true
 
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewPodReplicaLinksLagCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/pod_replica_links_performance_collector_test.go
+++ b/internal/openmetrics-exporter/pod_replica_links_performance_collector_test.go
@@ -41,7 +41,7 @@ func TestPodReplicaLinksPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_sec_total\"} label:{name:\"direction\" value:\"%s\"} label:{name:\"local_pod\" value:\"%s\"} label:{name:\"remote\" value:\"%s\"} label:{name:\"remote_pod\" value:\"%s\"} gauge:{value:%g}", p.Direction, p.LocalPod.Name, p.Remotes[0].Name, p.RemotePod.Name, p.BytesPerSecTotal)] = true
 
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewPodReplicaLinksPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/pods_performance_collector_test.go
+++ b/internal/openmetrics-exporter/pods_performance_collector_test.go
@@ -62,7 +62,7 @@ func TestPodsPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewPodsPerformanceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/pods_performance_replication_collector_test.go
+++ b/internal/openmetrics-exporter/pods_performance_replication_collector_test.go
@@ -49,7 +49,7 @@ func TestPodsPerformanceReplicationCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"sync\"} label:{name:\"direction\" value:\"total\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Pod.Name, p.SyncBytesPerSec.TotalBytesPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"periodic\"} label:{name:\"direction\" value:\"total\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", p.Pod.Name, p.PeriodicBytesPerSec.TotalBytesPerSec)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewPodsPerformanceReplicationCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/pods_space_collector_test.go
+++ b/internal/openmetrics-exporter/pods_space_collector_test.go
@@ -92,7 +92,7 @@ func TestPodsSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	pc := NewPodsSpaceCollector(c)
 	metricsCheck(t, pc, want)

--- a/internal/openmetrics-exporter/ports_collector_test.go
+++ b/internal/openmetrics-exporter/ports_collector_test.go
@@ -38,7 +38,7 @@ func TestPortsCollector(t *testing.T) {
 	for _, h := range hwl.Items {
 		want[fmt.Sprintf("label:{name:\"iqn\"  value:\"%s\"}  label:{name:\"name\"  value:\"%s\"}  label:{name:\"nqn\"  value:\"%s\"}  label:{name:\"portal\"  value:\"%s\"}  label:{name:\"wwn\"  value:\"%s\"}  gauge:{value:1}", h.Iqn, h.Name, h.Nqn, h.Portal, h.Wwn)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 	pc := NewPortsCollector(c)
 	metricsCheck(t, pc, want)
 	server.Close()

--- a/internal/openmetrics-exporter/volumes_performance_collector_test.go
+++ b/internal/openmetrics-exporter/volumes_performance_collector_test.go
@@ -74,7 +74,7 @@ func TestVolumesPerformanceCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_read\"} label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", naaid[p.Name], p.Name, p.BytesPerRead)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"bytes_per_write\"} label:{name:\"naa_id\" value:\"%s\"} label:{name:\"name\" value:\"%s\"} gauge:{value:%g}", naaid[p.Name], p.Name, p.BytesPerWrite)] = true
 	}
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 
 	vl := c.GetVolumes()
 	pc := NewVolumesPerformanceCollector(c, vl)

--- a/internal/openmetrics-exporter/volumes_space_collector_test.go
+++ b/internal/openmetrics-exporter/volumes_space_collector_test.go
@@ -82,7 +82,7 @@ func TestVolumesSpaceCollector(t *testing.T) {
 		}
 	}
 	defer server.Close()
-	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 	vl := c.GetVolumes()
 	pc := NewVolumesSpaceCollector(vl)
 	metricsCheck(t, pc, want)

--- a/internal/rest-client/alerts_test.go
+++ b/internal/rest-client/alerts_test.go
@@ -43,7 +43,7 @@ func TestAlerts(t *testing.T) {
 	endp := strings.Split(server.URL, "/")
 	e := endp[len(endp)-1]
 	t.Run("alerts_open", func(t *testing.T) {
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		al := c.GetAlerts("state='open'")
 		if diff := cmp.Diff(al.Items, aopen.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -51,7 +51,7 @@ func TestAlerts(t *testing.T) {
 		}
 	})
 	t.Run("alerts_all", func(t *testing.T) {
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		al := c.GetAlerts("")
 		if diff := cmp.Diff(al.Items, aall.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_performance_test.go
+++ b/internal/rest-client/arrays_performance_test.go
@@ -35,7 +35,7 @@ func TestArraysPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("arrays_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		apl := c.GetArraysPerformance()
 		if diff := cmp.Diff(apl.Items[0], arrsp.Items[0]); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_test.go
+++ b/internal/rest-client/arrays_test.go
@@ -35,7 +35,7 @@ func TestArrays(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("arrays_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		al := c.GetArrays()
 		if diff := cmp.Diff(al.Items[0], arrs.Items[0]); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/connections_test.go
+++ b/internal/rest-client/connections_test.go
@@ -35,7 +35,7 @@ func TestConnections(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("connections_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		cl := c.GetConnections()
 		if diff := cmp.Diff(cl.Items, conns.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/controllers_test.go
+++ b/internal/rest-client/controllers_test.go
@@ -35,7 +35,7 @@ func TestControllers(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("controllers_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		cl := c.GetControllers()
 		if diff := cmp.Diff(cl.Items, cont.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/directories_performance_test.go
+++ b/internal/rest-client/directories_performance_test.go
@@ -35,7 +35,7 @@ func TestDirectoriesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("directories_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		dpl := c.GetDirectoriesPerformance()
 		if diff := cmp.Diff(dpl.Items, dirsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/directories_test.go
+++ b/internal/rest-client/directories_test.go
@@ -35,7 +35,7 @@ func TestDirectories(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("directories_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		dl := c.GetDirectories()
 		if diff := cmp.Diff(dl.Items, dirs.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/drives_test.go
+++ b/internal/rest-client/drives_test.go
@@ -35,7 +35,7 @@ func TestDrive(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("drive_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		dl := c.GetDrives()
 		if diff := cmp.Diff(dl.Items, dr.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/flasharray_client.go
+++ b/internal/rest-client/flasharray_client.go
@@ -41,7 +41,7 @@ type FAClient struct {
 	Error      error
 }
 
-func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, rid string, debug bool) *FAClient {
+func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, rid string, debug bool, secure bool) *FAClient {
 	type ApiVersions struct {
 		Versions []string `json:"version"`
 	}
@@ -53,7 +53,9 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, uagent s
 		XAuthToken: "",
 	}
 	fa.RestClient.SetBaseURL("https://" + endpoint + "/api")
-	fa.RestClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	if !secure {
+		fa.RestClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	}
 	fa.RestClient.SetHeaders(map[string]string{
 		"Content-Type": "application/json",
 		"Accept":       "application/json",

--- a/internal/rest-client/flasharray_client_test.go
+++ b/internal/rest-client/flasharray_client_test.go
@@ -29,7 +29,7 @@ func TestNewRestClient(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("login", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		if c.EndPoint != e || c.ApiToken != "fake-api-token" || c.XAuthToken != "faketoken" {
 			t.Errorf("expected (%s, fake-api-token, faketoken), got (%s %s %s)", e, c.EndPoint, c.ApiToken, c.XAuthToken)
 		}

--- a/internal/rest-client/hardware_test.go
+++ b/internal/rest-client/hardware_test.go
@@ -35,7 +35,7 @@ func TestHardware(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hardware_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		hl := c.GetHardware()
 		if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_balance_test.go
+++ b/internal/rest-client/hosts_balance_test.go
@@ -35,7 +35,7 @@ func TestHostsBalance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_balance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		hbl := c.GetHostsBalance()
 		if diff := cmp.Diff(hbl.Items, hostsb.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_performance_test.go
+++ b/internal/rest-client/hosts_performance_test.go
@@ -34,7 +34,7 @@ func TestHostsPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		hpl := c.GetHostsPerformance()
 		if diff := cmp.Diff(hpl.Items, hostsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hosts_test.go
+++ b/internal/rest-client/hosts_test.go
@@ -35,7 +35,7 @@ func TestHosts(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("hosts_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		hl := c.GetHosts()
 		if diff := cmp.Diff(hl.Items, hosts.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/network_interface_test.go
+++ b/internal/rest-client/network_interface_test.go
@@ -35,7 +35,7 @@ func TestNetworkInterfaces(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("network_interfaces_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		nl := c.GetNetworkInterfaces()
 		if diff := cmp.Diff(nl.Items, nw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/network_performance_test.go
+++ b/internal/rest-client/network_performance_test.go
@@ -35,7 +35,7 @@ func TestNetworkInterfacesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("network_interfaces_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		nl := c.GetNetworkInterfacesPerformance()
 		if diff := cmp.Diff(nl.Items, nw.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pod_replica_links_lag_test.go
+++ b/internal/rest-client/pod_replica_links_lag_test.go
@@ -35,7 +35,7 @@ func TestPodReplicaLinksLag(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pod_replica_links_lag_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		prll := c.GetPodReplicaLinksLag()
 		if diff := cmp.Diff(prll.Items, podrll.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pod_replica_links_performance_test.go
+++ b/internal/rest-client/pod_replica_links_performance_test.go
@@ -35,7 +35,7 @@ func TestPodReplicaLinksPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pod_replica_links_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		prlpl := c.GetPodReplicaLinksPerformance()
 		if diff := cmp.Diff(prlpl.Items, podrlp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_performance_replication_test.go
+++ b/internal/rest-client/pods_performance_replication_test.go
@@ -35,7 +35,7 @@ func TestPodsPerformanceReplication(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_performance_replcation_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		ppl := c.GetPodsPerformanceReplication()
 		if diff := cmp.Diff(ppl.Items, podsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_performance_test.go
+++ b/internal/rest-client/pods_performance_test.go
@@ -35,7 +35,7 @@ func TestPodsPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		ppl := c.GetPodsPerformance()
 		if diff := cmp.Diff(ppl.Items, podsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/pods_test.go
+++ b/internal/rest-client/pods_test.go
@@ -35,7 +35,7 @@ func TestPods(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("pods_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		pl := c.GetPods()
 		if diff := cmp.Diff(pl.Items, pods.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/ports_test.go
+++ b/internal/rest-client/ports_test.go
@@ -35,7 +35,7 @@ func TestPorts(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("ports_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		pl := c.GetPorts()
 		if diff := cmp.Diff(pl.Items, ports.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/subscriptions_test.go
+++ b/internal/rest-client/subscriptions_test.go
@@ -35,7 +35,7 @@ func TestSubscriptions(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("subscriptions_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		vpl := c.GetSubscriptions()
 		if diff := cmp.Diff(vpl.Items, subs.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_performance_test.go
+++ b/internal/rest-client/volumes_performance_test.go
@@ -35,7 +35,7 @@ func TestVolumesPerformance(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("volumes_performance_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		vpl := c.GetVolumesPerformance()
 		if diff := cmp.Diff(vpl.Items, volsp.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/volumes_test.go
+++ b/internal/rest-client/volumes_test.go
@@ -35,7 +35,7 @@ func TestVolumes(t *testing.T) {
 	e := endp[len(endp)-1]
 	t.Run("volumes_1", func(t *testing.T) {
 		defer server.Close()
-		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false)
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", "test-X-Request-Id-string", false, false)
 		vl := c.GetVolumes()
 		if diff := cmp.Diff(vl.Items, vols.Items); diff != "" {
 			t.Errorf("Mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
closes #148 

Currently all calls from the exporter to the array are secure via tls, but not checked for the validity. 

This will use the system cert store to validate if the array should be trusted or not.