### PR TITLE
Remove exporter service from docker-compose example

### DIFF
--- a/examples/config/docker/docker-compose.yaml
+++ b/examples/config/docker/docker-compose.yaml
@@ -1,13 +1,4 @@
 services:
-  pure-fa-om-exporter:
-    image: quay.io/purestorage/pure-fa-om-exporter:latest
-    command: 
-      - '--port=9490'
-    depends_on: 
-      - prometheus
-    ports:
-      - 9490:9490
-    restart: unless-stopped
   prometheus:
     image: prom/prometheus:latest
     command:
@@ -26,7 +17,6 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin!
     depends_on: 
-      - pure-fa-om-exporter
       - prometheus
     ports:
       - 3000:3000


### PR DESCRIPTION
This PR updates the Docker Compose example to align with direct-to-array Prometheus scraping.

## Changes

- Remove pure-fa-om-exporter service (no longer needed when scraping directly from FlashArray)
- Update grafana depends_on to only require prometheus

## Why

This change accompanies PR #188 which updates the Prometheus configuration to scrape metrics directly from FlashArray endpoints. The exporter proxy service is no longer needed in this configuration, simplifying the deployment.